### PR TITLE
feat: Sprint 5 — Cart & Wishlist module

### DIFF
--- a/app/DTOs/Cart/AddCartItemDTO.php
+++ b/app/DTOs/Cart/AddCartItemDTO.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\DTOs\Cart;
+
+use App\Http\Requests\Cart\AddCartItemRequest;
+
+readonly class AddCartItemDTO
+{
+    public function __construct(
+        public int $variantId,
+        public int $quantity,
+    ) {}
+
+    public static function fromRequest(AddCartItemRequest $request): self
+    {
+        return new self(
+            variantId: $request->integer('variant_id'),
+            quantity:  $request->integer('quantity'),
+        );
+    }
+}

--- a/app/Http/Controllers/Api/Cart/CartController.php
+++ b/app/Http/Controllers/Api/Cart/CartController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers\Api\Cart;
+
+use App\DTOs\Cart\AddCartItemDTO;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Cart\AddCartItemRequest;
+use App\Http\Requests\Cart\UpdateCartItemRequest;
+use App\Http\Resources\Cart\CartResource;
+use App\Http\Responses\ApiResponse;
+use App\Models\CartItem;
+use App\Services\Cart\CartService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class CartController extends Controller
+{
+    public function __construct(
+        private readonly CartService $cart,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $cart = $this->cart->getForUser($request->user());
+
+        return ApiResponse::success('Cart retrieved.', new CartResource($cart));
+    }
+
+    public function store(AddCartItemRequest $request): JsonResponse
+    {
+        $cart = $this->cart->add($request->user(), AddCartItemDTO::fromRequest($request));
+
+        return ApiResponse::success('Item added to cart.', new CartResource($cart), 201);
+    }
+
+    public function update(UpdateCartItemRequest $request, CartItem $cartItem): JsonResponse
+    {
+        $cart = $this->cart->update($request->user(), $cartItem, $request->integer('quantity'));
+
+        return ApiResponse::success('Cart item updated.', new CartResource($cart));
+    }
+
+    public function destroy(Request $request, CartItem $cartItem): JsonResponse
+    {
+        $cart = $this->cart->remove($request->user(), $cartItem);
+
+        return ApiResponse::success('Item removed from cart.', new CartResource($cart));
+    }
+
+    public function clear(Request $request): \Illuminate\Http\Response
+    {
+        $this->cart->clear($request->user());
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Api/Cart/WishlistController.php
+++ b/app/Http/Controllers/Api/Cart/WishlistController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api\Cart;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Cart\WishlistResource;
+use App\Http\Responses\ApiResponse;
+use App\Services\Cart\WishlistService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class WishlistController extends Controller
+{
+    public function __construct(
+        private readonly WishlistService $wishlist,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $wishlist = $this->wishlist->getForUser($request->user());
+
+        return ApiResponse::success('Wishlist retrieved.', new WishlistResource($wishlist));
+    }
+
+    public function store(Request $request): JsonResponse
+    {
+        $request->validate(['product_id' => ['required', 'integer', 'exists:products,id']]);
+
+        $wishlist = $this->wishlist->add($request->user(), $request->integer('product_id'));
+
+        return ApiResponse::success('Product added to wishlist.', new WishlistResource($wishlist), 201);
+    }
+
+    public function destroy(Request $request, int $productId): \Illuminate\Http\Response
+    {
+        $this->wishlist->remove($request->user(), $productId);
+
+        return response()->noContent();
+    }
+
+    public function check(Request $request, int $productId): JsonResponse
+    {
+        $wishlisted = $this->wishlist->check($request->user(), $productId);
+
+        return ApiResponse::success('Wishlist check.', ['is_wishlisted' => $wishlisted]);
+    }
+}

--- a/app/Http/Controllers/Api/Cart/WishlistController.php
+++ b/app/Http/Controllers/Api/Cart/WishlistController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api\Cart;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Cart\AddWishlistItemRequest;
 use App\Http\Resources\Cart\WishlistResource;
 use App\Http\Responses\ApiResponse;
 use App\Services\Cart\WishlistService;
@@ -22,10 +23,8 @@ class WishlistController extends Controller
         return ApiResponse::success('Wishlist retrieved.', new WishlistResource($wishlist));
     }
 
-    public function store(Request $request): JsonResponse
+    public function store(AddWishlistItemRequest $request): JsonResponse
     {
-        $request->validate(['product_id' => ['required', 'integer', 'exists:products,id']]);
-
         $wishlist = $this->wishlist->add($request->user(), $request->integer('product_id'));
 
         return ApiResponse::success('Product added to wishlist.', new WishlistResource($wishlist), 201);

--- a/app/Http/Controllers/Api/Product/ProductController.php
+++ b/app/Http/Controllers/Api/Product/ProductController.php
@@ -39,9 +39,9 @@ class ProductController extends Controller
         ]);
     }
 
-    public function show(string $slug): JsonResponse
+    public function show(string $slug, Request $request): JsonResponse
     {
-        $product = $this->products->getProductDetail($slug);
+        $product = $this->products->getProductDetail($slug, $request->user());
 
         return ApiResponse::success('Product retrieved.', new ProductResource($product));
     }

--- a/app/Http/Requests/Cart/AddCartItemRequest.php
+++ b/app/Http/Requests/Cart/AddCartItemRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddCartItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'variant_id' => ['required', 'integer', 'exists:product_variants,id'],
+            'quantity'   => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/Cart/AddWishlistItemRequest.php
+++ b/app/Http/Requests/Cart/AddWishlistItemRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddWishlistItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'product_id' => ['required', 'integer', 'exists:products,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/Cart/UpdateCartItemRequest.php
+++ b/app/Http/Requests/Cart/UpdateCartItemRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Cart;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCartItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'quantity' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Resources/Cart/CartItemResource.php
+++ b/app/Http/Resources/Cart/CartItemResource.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Resources\Cart;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CartItemResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $variant  = $this->whenLoaded('variant');
+        $product  = $this->whenLoaded('product');
+        $isAvailable = $this->resource->product
+            && ! $this->resource->product->trashed()
+            && $this->resource->product->status->value === 'active';
+
+        $subtotal = $this->price_snapshot * $this->quantity;
+
+        return [
+            'id'                   => $this->id,
+            'product_id'           => $this->product_id,
+            'product_name'         => $this->resource->product?->name,
+            'product_slug'         => $this->resource->product?->slug,
+            'variant_id'           => $this->product_variant_id,
+            'variant_sku'          => $this->resource->variant?->sku,
+            'variant_attributes'   => $this->resource->variant?->attributes,
+            'quantity'             => $this->quantity,
+            'price_snapshot_cents' => $this->price_snapshot,
+            'price_snapshot'       => 'Rp ' . number_format($this->price_snapshot / 100, 0, ',', '.'),
+            'subtotal_cents'       => $subtotal,
+            'subtotal'             => 'Rp ' . number_format($subtotal / 100, 0, ',', '.'),
+            'current_stock'        => $this->resource->variant?->stock,
+            'is_available'         => $isAvailable,
+            'unavailable_reason'   => $isAvailable ? null : 'Produk tidak tersedia',
+            'thumbnail_url'        => $this->resource->product?->media
+                ?->firstWhere('is_primary', true)?->url,
+        ];
+    }
+}

--- a/app/Http/Resources/Cart/CartResource.php
+++ b/app/Http/Resources/Cart/CartResource.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Resources\Cart;
+
+use App\Enums\ProductStatus;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class CartResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $items = $this->items->loadMissing(['variant', 'product.media', 'store']);
+
+        $totalItems = $items->sum('quantity');
+        $totalCents = $items->sum(fn ($i) => $i->price_snapshot * $i->quantity);
+
+        $stores = $items
+            ->groupBy('store_id')
+            ->map(function ($storeItems, $storeId) {
+                $store        = $storeItems->first()->store;
+                $storeCents   = $storeItems->sum(fn ($i) => $i->price_snapshot * $i->quantity);
+
+                return [
+                    'store_id'            => $storeId,
+                    'store_name'          => $store?->name,
+                    'store_slug'          => $store?->slug,
+                    'items'               => CartItemResource::collection($storeItems)->resolve(),
+                    'store_subtotal_cents' => $storeCents,
+                    'store_subtotal'      => 'Rp ' . number_format($storeCents / 100, 0, ',', '.'),
+                ];
+            })
+            ->values();
+
+        return [
+            'total_items'        => $totalItems,
+            'total_price_cents'  => $totalCents,
+            'total_price'        => 'Rp ' . number_format($totalCents / 100, 0, ',', '.'),
+            'stores'             => $stores,
+        ];
+    }
+}

--- a/app/Http/Resources/Cart/WishlistItemResource.php
+++ b/app/Http/Resources/Cart/WishlistItemResource.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Resources\Cart;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WishlistItemResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        $product     = $this->product;
+        $isAvailable = $product && ! $product->trashed()
+            && $product->status->value === 'active';
+
+        return [
+            'id'              => $this->id,
+            'product_id'      => $this->product_id,
+            'name'            => $product?->name,
+            'slug'            => $product?->slug,
+            'min_price_cents' => $product?->min_price,
+            'min_price'       => $product ? 'Rp ' . number_format($product->min_price / 100, 0, ',', '.') : null,
+            'status'          => $product?->status->value,
+            'total_stock'     => $product?->total_stock,
+            'is_available'    => $isAvailable,
+            'thumbnail_url'   => $product?->media
+                ?->firstWhere('is_primary', true)?->url,
+            'added_at'        => $this->created_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Resources/Cart/WishlistResource.php
+++ b/app/Http/Resources/Cart/WishlistResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Http\Resources\Cart;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class WishlistResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'total' => $this->items->count(),
+            'items' => WishlistItemResource::collection($this->items),
+        ];
+    }
+}

--- a/app/Http/Resources/Product/ProductResource.php
+++ b/app/Http/Resources/Product/ProductResource.php
@@ -35,6 +35,7 @@ class ProductResource extends JsonResource
             ]),
             'variants'        => $this->whenLoaded('variants', fn () => VariantResource::collection($this->variants)),
             'media'           => $this->whenLoaded('media', fn () => ProductMediaResource::collection($this->media)),
+            'is_wishlisted'   => $this->when(isset($this->is_wishlisted), $this->is_wishlisted),
             'created_at'      => $this->created_at?->toISOString(),
             'updated_at'      => $this->updated_at?->toISOString(),
         ];

--- a/app/Listeners/Auth/SendWelcomeEmail.php
+++ b/app/Listeners/Auth/SendWelcomeEmail.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Listeners\Auth;
+
+use App\Contracts\Shared\EmailServiceInterface;
+use App\Events\Auth\UserRegistered;
+use App\Mail\Auth\WelcomeMail;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class SendWelcomeEmail implements ShouldQueue
+{
+    public function __construct(
+        private readonly EmailServiceInterface $email,
+    ) {}
+
+    public function handle(UserRegistered $event): void
+    {
+        $this->email->send($event->user, new WelcomeMail($event->user));
+    }
+}

--- a/app/Mail/Auth/WelcomeMail.php
+++ b/app/Mail/Auth/WelcomeMail.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Mail\Auth;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class WelcomeMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly User $user,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(subject: 'Welcome to Marketplace!');
+    }
+
+    public function content(): Content
+    {
+        return new Content(view: 'emails.auth.welcome');
+    }
+}

--- a/app/Models/Cart.php
+++ b/app/Models/Cart.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Cart extends Model
+{
+    protected $fillable = ['user_id'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(CartItem::class);
+    }
+}

--- a/app/Models/CartItem.php
+++ b/app/Models/CartItem.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CartItem extends Model
+{
+    protected $fillable = [
+        'cart_id',
+        'product_variant_id',
+        'product_id',
+        'store_id',
+        'quantity',
+        'price_snapshot',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'quantity'       => 'integer',
+            'price_snapshot' => 'integer',
+            'product_id'     => 'integer',
+            'store_id'       => 'integer',
+        ];
+    }
+
+    public function cart(): BelongsTo
+    {
+        return $this->belongsTo(Cart::class);
+    }
+
+    public function variant(): BelongsTo
+    {
+        return $this->belongsTo(ProductVariant::class, 'product_variant_id');
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+
+    public function store(): BelongsTo
+    {
+        return $this->belongsTo(Store::class);
+    }
+}

--- a/app/Models/Wishlist.php
+++ b/app/Models/Wishlist.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Wishlist extends Model
+{
+    protected $fillable = ['user_id'];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(WishlistItem::class);
+    }
+}

--- a/app/Models/WishlistItem.php
+++ b/app/Models/WishlistItem.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WishlistItem extends Model
+{
+    protected $fillable = ['wishlist_id', 'product_id'];
+
+    public function wishlist(): BelongsTo
+    {
+        return $this->belongsTo(Wishlist::class);
+    }
+
+    public function product(): BelongsTo
+    {
+        return $this->belongsTo(Product::class);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use App\Events\Auth\UserRegistered;
 use App\Events\Merchant\StoreFollowed;
 use App\Events\Merchant\StoreUnfollowed;
 use App\Listeners\Auth\SendEmailVerificationNotification;
+use App\Listeners\Auth\SendWelcomeEmail;
 use App\Listeners\Merchant\DecrementFollowerCount;
 use App\Listeners\Merchant\IncrementFollowerCount;
 use App\Models\ProductVariant;
@@ -46,6 +47,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         Event::listen(UserRegistered::class, SendEmailVerificationNotification::class);
+        Event::listen(UserRegistered::class, SendWelcomeEmail::class);
         Event::listen(StoreFollowed::class, IncrementFollowerCount::class);
         Event::listen(StoreUnfollowed::class, DecrementFollowerCount::class);
 

--- a/app/Services/Cart/CartService.php
+++ b/app/Services/Cart/CartService.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Services\Cart;
+
+use App\Contracts\Shared\CacheServiceInterface;
+use App\DTOs\Cart\AddCartItemDTO;
+use App\Enums\ProductStatus;
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\ProductVariant;
+use App\Models\User;
+
+class CartService
+{
+    public function __construct(
+        private readonly CacheServiceInterface $cache,
+    ) {}
+
+    public function getForUser(User $user): Cart
+    {
+        $cacheKey = "cart:user:{$user->id}";
+
+        // Cache only the cart record (not relationships — they must be fresh to detect stock/availability changes)
+        $cart = $this->cache->remember($cacheKey, 86400, fn () =>
+            Cart::firstOrCreate(['user_id' => $user->id])
+        );
+
+        $cart->load([
+            'items.variant',
+            'items.product' => fn ($q) => $q->withTrashed(),
+            'items.store:id,name,slug',
+        ]);
+
+        return $cart;
+    }
+
+    public function add(User $user, AddCartItemDTO $data): Cart
+    {
+        $variant = ProductVariant::with('product')->findOrFail($data->variantId);
+
+        if ($variant->product->status !== ProductStatus::Active) {
+            throw new \DomainException('Only active products can be added to cart.');
+        }
+
+        if ($data->quantity > $variant->stock) {
+            throw new \DomainException("Stok tersedia: {$variant->stock}");
+        }
+
+        $cart = Cart::firstOrCreate(['user_id' => $user->id]);
+
+        $existing = $cart->items()->where('product_variant_id', $variant->id)->first();
+
+        if ($existing) {
+            $newQty = $existing->quantity + $data->quantity;
+            if ($newQty > $variant->stock) {
+                throw new \DomainException("Stok tersedia: {$variant->stock}");
+            }
+            $existing->update(['quantity' => $newQty]);
+        } else {
+            $cart->items()->create([
+                'product_variant_id' => $variant->id,
+                'product_id'         => $variant->product_id,
+                'store_id'           => $variant->product->store_id,
+                'quantity'           => $data->quantity,
+                'price_snapshot'     => $variant->price,
+            ]);
+        }
+
+        $this->invalidateCache($user->id);
+
+        return $this->getForUser($user);
+    }
+
+    public function update(User $user, CartItem $item, int $quantity): Cart
+    {
+        $this->authorizeItem($user, $item);
+
+        $variant = $item->variant;
+        if ($quantity > $variant->stock) {
+            throw new \DomainException("Stok tersedia: {$variant->stock}");
+        }
+
+        $item->update(['quantity' => $quantity]);
+        $this->invalidateCache($user->id);
+
+        return $this->getForUser($user);
+    }
+
+    public function remove(User $user, CartItem $item): Cart
+    {
+        $this->authorizeItem($user, $item);
+        $item->delete();
+        $this->invalidateCache($user->id);
+
+        return $this->getForUser($user);
+    }
+
+    public function clear(User $user): void
+    {
+        $cart = Cart::where('user_id', $user->id)->first();
+        $cart?->items()->delete();
+        $this->invalidateCache($user->id);
+    }
+
+    public function groupByStore(Cart $cart): array
+    {
+        $groups = [];
+
+        foreach ($cart->items as $item) {
+            $isAvailable = $item->product && ! $item->product->trashed()
+                && $item->product->status === ProductStatus::Active;
+
+            $storeId = $item->store_id;
+
+            if (! isset($groups[$storeId])) {
+                $groups[$storeId] = [
+                    'store' => $item->store,
+                    'items' => [],
+                ];
+            }
+
+            $groups[$storeId]['items'][] = [
+                'item'         => $item,
+                'is_available' => $isAvailable,
+            ];
+        }
+
+        return $groups;
+    }
+
+    private function authorizeItem(User $user, CartItem $item): void
+    {
+        $cart = Cart::where('user_id', $user->id)->first();
+        if (! $cart || $item->cart_id !== $cart->id) {
+            throw new \DomainException('Cart item does not belong to this user.');
+        }
+    }
+
+    private function invalidateCache(int $userId): void
+    {
+        $this->cache->forget("cart:user:{$userId}");
+    }
+}

--- a/app/Services/Cart/CartService.php
+++ b/app/Services/Cart/CartService.php
@@ -20,11 +20,12 @@ class CartService
     {
         $cacheKey = "cart:user:{$user->id}";
 
-        // Cache only the cart record (not relationships — they must be fresh to detect stock/availability changes)
-        $cart = $this->cache->remember($cacheKey, 86400, fn () =>
-            Cart::firstOrCreate(['user_id' => $user->id])
-        );
+        // Cache only the cart ID (integer) — never cache model objects to avoid unserialize failures
+        $cartId = $this->cache->remember($cacheKey, 86400, function () use ($user) {
+            return Cart::firstOrCreate(['user_id' => $user->id])->id;
+        });
 
+        $cart = Cart::findOrFail($cartId);
         $cart->load([
             'items.variant',
             'items.product' => fn ($q) => $q->withTrashed(),

--- a/app/Services/Cart/WishlistService.php
+++ b/app/Services/Cart/WishlistService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Services\Cart;
+
+use App\Models\Product;
+use App\Models\User;
+use App\Models\Wishlist;
+use App\Models\WishlistItem;
+
+class WishlistService
+{
+    public function getForUser(User $user): Wishlist
+    {
+        $wishlist = Wishlist::firstOrCreate(['user_id' => $user->id]);
+        $wishlist->load(['items.product.media' => fn ($q) => $q->where('is_primary', true)]);
+        return $wishlist;
+    }
+
+    public function add(User $user, int $productId): Wishlist
+    {
+        $product = Product::findOrFail($productId);
+
+        $wishlist = Wishlist::firstOrCreate(['user_id' => $user->id]);
+
+        $exists = $wishlist->items()->where('product_id', $product->id)->exists();
+        if ($exists) {
+            throw new \DomainException('Product is already in your wishlist.');
+        }
+
+        $wishlist->items()->create(['product_id' => $product->id]);
+
+        return $this->getForUser($user);
+    }
+
+    public function remove(User $user, int $productId): void
+    {
+        $wishlist = Wishlist::where('user_id', $user->id)->first();
+
+        if (! $wishlist) {
+            return;
+        }
+
+        $wishlist->items()->where('product_id', $productId)->delete();
+    }
+
+    public function check(User $user, int $productId): bool
+    {
+        $wishlist = Wishlist::where('user_id', $user->id)->first();
+
+        if (! $wishlist) {
+            return false;
+        }
+
+        return $wishlist->items()->where('product_id', $productId)->exists();
+    }
+}

--- a/app/Services/Product/ProductService.php
+++ b/app/Services/Product/ProductService.php
@@ -11,6 +11,8 @@ use App\Models\Product;
 use App\Models\ProductMedia;
 use App\Models\ProductVariant;
 use App\Models\Store;
+use App\Models\User;
+use App\Models\Wishlist;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Str;
@@ -135,14 +137,23 @@ class ProductService
         return Product::where('store_id', $storeId)->latest()->paginate(20);
     }
 
-    public function getProductDetail(string $slug): Product
+    public function getProductDetail(string $slug, ?User $user = null): Product
     {
-        return $this->cache->remember("product:detail:{$slug}", 300, fn () =>
+        $product = $this->cache->remember("product:detail:{$slug}", 300, fn () =>
             Product::with(['store:id,name,slug', 'category:id,name,slug', 'variants', 'media'])
                 ->where('slug', $slug)
                 ->where('status', ProductStatus::Active)
                 ->firstOrFail()
         );
+
+        if ($user) {
+            $wishlist = Wishlist::where('user_id', $user->id)->first();
+            $product->is_wishlisted = $wishlist
+                ? $wishlist->items()->where('product_id', $product->id)->exists()
+                : false;
+        }
+
+        return $product;
     }
 
     // ── Media ─────────────────────────────────────────────────────────────────

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -61,4 +61,8 @@ return Application::configure(basePath: dirname(__DIR__))
         $exceptions->render(function (\App\Exceptions\Merchant\AlreadyFollowingException $e) {
             return \App\Http\Responses\ApiResponse::error('You are already following this store.', 409);
         });
+
+        $exceptions->render(function (\DomainException $e) {
+            return \App\Http\Responses\ApiResponse::error($e->getMessage(), 422);
+        });
     })->create();

--- a/database/factories/CartFactory.php
+++ b/database/factories/CartFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cart;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Cart>
+ */
+class CartFactory extends Factory
+{
+    protected $model = Cart::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/CartItemFactory.php
+++ b/database/factories/CartItemFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\Store;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CartItem>
+ */
+class CartItemFactory extends Factory
+{
+    protected $model = CartItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'cart_id'            => Cart::factory(),
+            'product_variant_id' => ProductVariant::factory(),
+            'product_id'         => Product::factory(),
+            'store_id'           => Store::factory(),
+            'quantity'           => $this->faker->numberBetween(1, 5),
+            'price_snapshot'     => $this->faker->numberBetween(10000, 1000000),
+        ];
+    }
+}

--- a/database/factories/WishlistFactory.php
+++ b/database/factories/WishlistFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\Wishlist;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Wishlist>
+ */
+class WishlistFactory extends Factory
+{
+    protected $model = Wishlist::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/WishlistItemFactory.php
+++ b/database/factories/WishlistItemFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\Wishlist;
+use App\Models\WishlistItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<WishlistItem>
+ */
+class WishlistItemFactory extends Factory
+{
+    protected $model = WishlistItem::class;
+
+    public function definition(): array
+    {
+        return [
+            'wishlist_id' => Wishlist::factory(),
+            'product_id'  => Product::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_05_07_184801_create_carts_table.php
+++ b/database/migrations/2026_05_07_184801_create_carts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('carts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('carts');
+    }
+};

--- a/database/migrations/2026_05_07_184802_create_cart_items_table.php
+++ b/database/migrations/2026_05_07_184802_create_cart_items_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cart_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('cart_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_variant_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('product_id');
+            $table->unsignedBigInteger('store_id');
+            $table->unsignedInteger('quantity');
+            $table->unsignedBigInteger('price_snapshot');
+            $table->timestamps();
+
+            $table->unique(['cart_id', 'product_variant_id']);
+            $table->index('store_id');
+            $table->index('product_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cart_items');
+    }
+};

--- a/database/migrations/2026_05_07_184803_create_wishlists_table.php
+++ b/database/migrations/2026_05_07_184803_create_wishlists_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('wishlists', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->unique()->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('wishlists');
+    }
+};

--- a/database/migrations/2026_05_07_184804_create_wishlist_items_table.php
+++ b/database/migrations/2026_05_07_184804_create_wishlist_items_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('wishlist_items', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('wishlist_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('product_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->unique(['wishlist_id', 'product_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('wishlist_items');
+    }
+};

--- a/database/seeders/AdminUserSeeder.php
+++ b/database/seeders/AdminUserSeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class AdminUserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory()->admin()->create([
+            'name'     => 'Super Admin',
+            'email'    => 'admin@marketplace.dev',
+            'password' => bcrypt('admin123'),
+        ]);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -15,11 +15,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(DevSeeder::class);
     }
 }

--- a/database/seeders/DevSeeder.php
+++ b/database/seeders/DevSeeder.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\KycStatus;
+use App\Enums\MerchantStatus;
+use App\Enums\ProductStatus;
+use App\Enums\UserRole;
+use App\Models\Cart;
+use App\Models\Category;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class DevSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // ── Admin ─────────────────────────────────────────────────────────────
+        $admin = User::firstOrCreate(['email' => 'admin@marketplace.dev'], [
+            'name'              => 'Super Admin',
+            'password'          => Hash::make('password123'),
+            'role'              => UserRole::Admin,
+            'email_verified_at' => now(),
+        ]);
+
+        // ── Categories ────────────────────────────────────────────────────────
+        $elektronik = $this->category('Elektronik', 'elektronik', 1);
+        $fashion     = $this->category('Fashion', 'fashion', 2);
+        $olahraga    = $this->category('Olahraga', 'olahraga', 3);
+
+        $hp      = $this->category('Handphone', 'handphone', 1, $elektronik->id);
+        $laptop  = $this->category('Laptop', 'laptop', 2, $elektronik->id);
+        $sepatu  = $this->category('Sepatu', 'sepatu', 1, $olahraga->id);
+        $baju    = $this->category('Baju', 'baju', 1, $fashion->id);
+
+        // ── Merchant user ─────────────────────────────────────────────────────
+        $merchant = User::firstOrCreate(['email' => 'merchant@marketplace.dev'], [
+            'name'              => 'Merchant Demo',
+            'password'          => Hash::make('password123'),
+            'role'              => UserRole::Merchant,
+            'email_verified_at' => now(),
+        ]);
+
+        $store = Store::firstOrCreate(['user_id' => $merchant->id], [
+            'name'        => 'Toko Demo',
+            'slug'        => 'toko-demo',
+            'description' => 'Toko untuk keperluan demo dan testing',
+            'status'      => MerchantStatus::Active,
+            'kyc_status'  => KycStatus::Approved,
+            'city'        => 'Bandung',
+            'province'    => 'Jawa Barat',
+        ]);
+
+        // ── Products ──────────────────────────────────────────────────────────
+        $sepatuProduk = $this->product($store, $sepatu, [
+            'name'        => 'Sepatu Lari Pro',
+            'slug'        => 'sepatu-lari-pro',
+            'description' => 'Sepatu lari berkualitas tinggi cocok untuk marathon dan trail running.',
+            'status'      => ProductStatus::Active,
+            'weight_gram' => 350,
+        ]);
+
+        $this->variant($sepatuProduk, 'SKU-SLP-39', 39000000, 25, ['ukuran' => '39', 'warna' => 'Hitam']);
+        $this->variant($sepatuProduk, 'SKU-SLP-40', 39000000, 30, ['ukuran' => '40', 'warna' => 'Hitam']);
+        $this->variant($sepatuProduk, 'SKU-SLP-41', 40000000, 20, ['ukuran' => '41', 'warna' => 'Putih']);
+        $this->variant($sepatuProduk, 'SKU-SLP-42', 40000000, 15, ['ukuran' => '42', 'warna' => 'Putih']);
+
+        $hpProduk = $this->product($store, $hp, [
+            'name'        => 'Smartphone XZ Pro',
+            'slug'        => 'smartphone-xz-pro',
+            'description' => 'Smartphone flagship dengan kamera 200MP dan baterai 6000mAh.',
+            'status'      => ProductStatus::Active,
+            'weight_gram' => 210,
+        ]);
+
+        $this->variant($hpProduk, 'SKU-XZ-128-BLK', 599900000, 10, ['storage' => '128GB', 'warna' => 'Hitam']);
+        $this->variant($hpProduk, 'SKU-XZ-256-BLK', 699900000, 8,  ['storage' => '256GB', 'warna' => 'Hitam']);
+        $this->variant($hpProduk, 'SKU-XZ-256-WHT', 699900000, 5,  ['storage' => '256GB', 'warna' => 'Putih']);
+
+        $bajuProduk = $this->product($store, $baju, [
+            'name'        => 'Kaos Polos Premium',
+            'slug'        => 'kaos-polos-premium',
+            'description' => 'Kaos bahan combed 30s, adem dan nyaman dipakai sehari-hari.',
+            'status'      => ProductStatus::Active,
+            'weight_gram' => 180,
+        ]);
+
+        $this->variant($bajuProduk, 'SKU-KPP-S-PTH', 8900000, 50, ['ukuran' => 'S', 'warna' => 'Putih']);
+        $this->variant($bajuProduk, 'SKU-KPP-M-PTH', 8900000, 50, ['ukuran' => 'M', 'warna' => 'Putih']);
+        $this->variant($bajuProduk, 'SKU-KPP-L-HTM', 8900000, 40, ['ukuran' => 'L', 'warna' => 'Hitam']);
+        $this->variant($bajuProduk, 'SKU-KPP-XL-HTM', 9500000, 30, ['ukuran' => 'XL', 'warna' => 'Hitam']);
+
+        // ── Buyer user with cart ───────────────────────────────────────────────
+        $buyer = User::firstOrCreate(['email' => 'test@example.com'], [
+            'name'              => 'Test User',
+            'password'          => Hash::make('password123'),
+            'role'              => UserRole::Buyer,
+            'email_verified_at' => now(),
+        ]);
+
+        // Seed cart with 2 items from the same store
+        $cart = Cart::firstOrCreate(['user_id' => $buyer->id]);
+
+        $variantSepatu = ProductVariant::where('sku', 'SKU-SLP-40')->first();
+        $variantHp     = ProductVariant::where('sku', 'SKU-XZ-128-BLK')->first();
+
+        if ($variantSepatu && ! $cart->items()->where('product_variant_id', $variantSepatu->id)->exists()) {
+            $cart->items()->create([
+                'product_variant_id' => $variantSepatu->id,
+                'product_id'         => $variantSepatu->product_id,
+                'store_id'           => $store->id,
+                'quantity'           => 1,
+                'price_snapshot'     => $variantSepatu->price,
+            ]);
+        }
+
+        if ($variantHp && ! $cart->items()->where('product_variant_id', $variantHp->id)->exists()) {
+            $cart->items()->create([
+                'product_variant_id' => $variantHp->id,
+                'product_id'         => $variantHp->product_id,
+                'store_id'           => $store->id,
+                'quantity'           => 1,
+                'price_snapshot'     => $variantHp->price,
+            ]);
+        }
+
+        // ── Second merchant (untuk test multi-store cart) ──────────────────────
+        $merchant2 = User::firstOrCreate(['email' => 'merchant2@marketplace.dev'], [
+            'name'              => 'Merchant Dua',
+            'password'          => Hash::make('password123'),
+            'role'              => UserRole::Merchant,
+            'email_verified_at' => now(),
+        ]);
+
+        $store2 = Store::firstOrCreate(['user_id' => $merchant2->id], [
+            'name'        => 'Toko Gadget',
+            'slug'        => 'toko-gadget',
+            'description' => 'Toko gadget dan aksesoris elektronik',
+            'status'      => MerchantStatus::Active,
+            'kyc_status'  => KycStatus::Approved,
+            'city'        => 'Jakarta',
+            'province'    => 'DKI Jakarta',
+        ]);
+
+        $laptopProduk = $this->product($store2, $laptop, [
+            'name'        => 'Laptop Ultra Slim',
+            'slug'        => 'laptop-ultra-slim',
+            'description' => 'Laptop tipis 14 inch, Intel Core i7, RAM 16GB, SSD 512GB.',
+            'status'      => ProductStatus::Active,
+            'weight_gram' => 1400,
+        ]);
+
+        $variantLaptop = $this->variant($laptopProduk, 'SKU-LUS-SLV', 1299900000, 5, ['warna' => 'Silver']);
+        $this->variant($laptopProduk, 'SKU-LUS-GLD', 1299900000, 3, ['warna' => 'Gold']);
+
+        // Add laptop to buyer's cart (multi-store scenario)
+        if (! $cart->items()->where('product_variant_id', $variantLaptop->id)->exists()) {
+            $cart->items()->create([
+                'product_variant_id' => $variantLaptop->id,
+                'product_id'         => $variantLaptop->product_id,
+                'store_id'           => $store2->id,
+                'quantity'           => 1,
+                'price_snapshot'     => $variantLaptop->price,
+            ]);
+        }
+
+        $this->command->info('DevSeeder selesai:');
+        $this->command->table(
+            ['Role', 'Email', 'Password'],
+            [
+                ['Admin',     'admin@marketplace.dev',     'password123'],
+                ['Merchant',  'merchant@marketplace.dev',  'password123'],
+                ['Merchant2', 'merchant2@marketplace.dev', 'password123'],
+                ['Buyer',     'test@example.com',          'password123'],
+            ]
+        );
+        $this->command->info('Cart test@example.com: 3 items dari 2 toko (multi-store)');
+    }
+
+    private function category(string $name, string $slug, int $sort, ?int $parentId = null): Category
+    {
+        return Category::firstOrCreate(['slug' => $slug], [
+            'parent_id'  => $parentId,
+            'name'       => $name,
+            'slug'       => $slug,
+            'level'      => $parentId ? 2 : 1,
+            'sort_order' => $sort,
+        ]);
+    }
+
+    private function product(Store $store, Category $category, array $attrs): Product
+    {
+        return Product::firstOrCreate(['slug' => $attrs['slug']], array_merge($attrs, [
+            'store_id'    => $store->id,
+            'category_id' => $category->id,
+            'min_price'   => 0,
+            'max_price'   => 0,
+            'total_stock' => 0,
+            'sold_count'  => 0,
+            'rating_avg'  => 0,
+        ]));
+    }
+
+    private function variant(Product $product, string $sku, int $price, int $stock, array $attributes): ProductVariant
+    {
+        return ProductVariant::firstOrCreate(['sku' => $sku], [
+            'product_id'  => $product->id,
+            'sku'         => $sku,
+            'price'       => $price,
+            'stock'       => $stock,
+            'weight_gram' => $product->weight_gram,
+            'attributes'  => $attributes,
+        ]);
+    }
+}

--- a/planning/05-cart.md
+++ b/planning/05-cart.md
@@ -1,5 +1,5 @@
 # MODULE 5 — Cart & Wishlist
-**Priority:** 🟠 P1 | **Status:** ⬜ Belum | **Sprint:** 5
+**Priority:** 🟠 P1 | **Status:** 🟡 In Review | **Sprint:** 5
 
 ---
 

--- a/planning/05-cart.md
+++ b/planning/05-cart.md
@@ -5,77 +5,308 @@
 
 ## Yang Perlu Dibangun
 - ⬜ Add/update/remove item ke cart
-- ⬜ Cart persistence: Redis (fast read) + DB (permanent backup)
-- ⬜ Multi-store cart grouping (group by merchant saat checkout)
-- ⬜ Stock validation saat add to cart & checkout
+- ⬜ Cart persistence: **DB as source of truth** + Redis cache response (TTL 86400s)
+- ⬜ Multi-store cart grouping via `store_id` di `cart_items` (denormalized)
+- ⬜ Stock validation saat add to cart & checkout (re-validate dengan FOR UPDATE lock)
 - ⬜ Wishlist CRUD
 - ⬜ Check if product already in wishlist
-- ⬜ Notifikasi harga turun untuk wishlist item (P2)
+- ⬜ `is_wishlisted` field di product detail response (saat authenticated)
+- ⬜ Welcome Email (WelcomeMail + SendWelcomeEmail listener — carryover dari Sprint 1)
+
+### Ditunda (Deferred)
+- ❌ **Guest cart** — merge logic saat login terlalu kompleks untuk MVP. Require login sebelum cart. Defer ke post-P2.
+- ❌ **Abandoned cart expiry job** — cleanup cart yang tidak aktif >30 hari. Defer ke P2.
+- ❌ **Notifikasi harga turun untuk wishlist** — Defer ke Sprint 10 (Notification module).
 
 ---
 
 ## Entities
+
 | Tabel | Kolom Utama |
 |---|---|
-| `carts` | `user_id`, `expires_at` |
-| `cart_items` | `cart_id`, `product_variant_id`, `quantity`, `price_snapshot` (harga saat ditambah) |
-| `wishlists` | `user_id` |
-| `wishlist_items` | `wishlist_id`, `product_id`, `added_at` |
+| `carts` | `id`, `user_id` (unique), `timestamps` |
+| `cart_items` | `id`, `cart_id`, `product_variant_id`, `product_id` *(denorm)*, `store_id` *(denorm)*, `quantity`, `price_snapshot` (integer cents), `timestamps` |
+| `wishlists` | `id`, `user_id` (unique), `timestamps` |
+| `wishlist_items` | `id`, `wishlist_id`, `product_id`, `timestamps` |
+
+> **Catatan Desain:**
+> - `carts.user_id` unique — satu user satu cart permanen (tidak perlu expires_at)
+> - `cart_items.store_id` — denormalized dari `product.store_id` saat item ditambah. Dipakai untuk `groupByStore()` tanpa extra join
+> - `cart_items.product_id` — denormalized untuk soft-delete handling (product soft-deleted tapi cart item masih bisa ditampilkan dengan warning)
+> - `cart_items.price_snapshot` — integer cents, harga saat item ditambahkan. Tidak berubah meski harga produk berubah setelahnya
+> - `wishlist_items` tidak perlu `added_at` custom — pakai `created_at` dari Eloquent timestamps
+> - `wishlists.user_id` unique — satu wishlist per user (future: multi-wishlist jika dibutuhkan)
+
+---
+
+## Persistence Strategy
+
+**Bukan dual-write.** Pattern yang dipakai:
+
+```
+Write path:  CartController → CartService → DB (source of truth) → invalidate Redis cache
+Read path:   CartController → Redis cache hit? → return cached
+                                    ↓ miss
+                           DB → transform → cache di Redis → return
+```
+
+Redis key: `cart:user:{user_id}` TTL 86400s
+Cache di-invalidate setiap kali ada perubahan (add/update/remove/clear).
+
+---
+
+## Enums / Flags
+
+Tidak ada enum baru. Gunakan `ProductStatus` untuk validasi (hanya `active` product yang bisa di-add to cart).
 
 ---
 
 ## Routes
-```
-GET    /api/cart                               [auth]
-POST   /api/cart/items                         [auth]
-PUT    /api/cart/items/{cartItemId}            [auth]
-DELETE /api/cart/items/{cartItemId}            [auth]
-DELETE /api/cart                               [auth] (clear all)
 
-GET    /api/wishlist                           [auth]
-POST   /api/wishlist/items                     [auth]
-DELETE /api/wishlist/items/{productId}         [auth]
-GET    /api/wishlist/items/{productId}/check   [auth]
+```
+# Cart
+GET    /api/cart                               [auth:sanctum]
+POST   /api/cart/items                         [auth:sanctum]
+PUT    /api/cart/items/{cartItemId}            [auth:sanctum]
+DELETE /api/cart/items/{cartItemId}            [auth:sanctum]
+DELETE /api/cart                               [auth:sanctum]  ← clear all (dipakai setelah checkout)
+
+# Wishlist
+GET    /api/wishlist                           [auth:sanctum]
+POST   /api/wishlist/items                     [auth:sanctum]
+DELETE /api/wishlist/items/{productId}         [auth:sanctum]
+GET    /api/wishlist/items/{productId}/check   [auth:sanctum]  ← quick check untuk UI toggle
+```
+
+> **`is_wishlisted` di product detail:** `GET /api/products/{slug}` saat authenticated akan include
+> field `is_wishlisted: bool` (query `wishlist_items` by authenticated user). Ini dilakukan di
+> `ProductService::findBySlug(string $slug, ?User $user)` — jika `$user` null (guest), field tidak disertakan.
+
+---
+
+## DTOs
+
+```php
+// app/DTOs/Cart/AddCartItemDTO.php
+readonly class AddCartItemDTO {
+    public function __construct(
+        public int $variantId,
+        public int $quantity,
+    ) {}
+
+    public static function fromRequest(AddCartItemRequest $request): self
+    {
+        return new self(
+            variantId: $request->integer('variant_id'),
+            quantity:  $request->integer('quantity'),
+        );
+    }
+}
 ```
 
 ---
 
 ## Files to Create
+
 ```
+# DTOs
+app/DTOs/Cart/AddCartItemDTO.php
+
+# Controllers
 app/Http/Controllers/Api/Cart/CartController.php
 app/Http/Controllers/Api/Cart/WishlistController.php
-app/Http/Requests/Cart/AddCartItemRequest.php
-app/Http/Requests/Cart/UpdateCartItemRequest.php
-app/Http/Resources/Cart/CartResource.php
-app/Http/Resources/Cart/CartItemResource.php
-app/Http/Resources/Cart/WishlistResource.php
+
+# Form Requests
+app/Http/Requests/Cart/AddCartItemRequest.php       ← variant_id (exists, active), quantity (min:1)
+app/Http/Requests/Cart/UpdateCartItemRequest.php    ← quantity (min:1)
+
+# Resources
+app/Http/Resources/Cart/CartResource.php            ← total_items, total_price, grouped_by_store, items[]
+app/Http/Resources/Cart/CartItemResource.php        ← variant info, price_snapshot, qty, subtotal, store_id
+app/Http/Resources/Cart/WishlistResource.php        ← items[], total
+app/Http/Resources/Cart/WishlistItemResource.php    ← product summary (id, name, slug, price, status)
+
+# Services
 app/Services/Cart/CartService.php
 app/Services/Cart/WishlistService.php
+
+# Models
 app/Models/Cart.php
 app/Models/CartItem.php
 app/Models/Wishlist.php
 app/Models/WishlistItem.php
+
+# Migrations
 database/migrations/xxxx_create_carts_table.php
 database/migrations/xxxx_create_cart_items_table.php
 database/migrations/xxxx_create_wishlists_table.php
 database/migrations/xxxx_create_wishlist_items_table.php
+
+# Routes
 routes/api/cart.php
+
+# Welcome Email (carryover Sprint 1)
+app/Mail/Auth/WelcomeMail.php
+app/Listeners/Auth/SendWelcomeEmail.php             ← listen UserRegistered, ShouldQueue
+
+# Tests
 tests/Feature/Api/Cart/CartTest.php
 tests/Feature/Api/Cart/WishlistTest.php
+tests/Unit/Services/Cart/CartServiceTest.php
 ```
 
 ---
 
 ## Shared Services Needed
+
 | Service | Kegunaan |
 |---|---|
-| `CacheService` | Redis cart storage (key: `cart:{user_id}`, TTL: 86400s) |
+| `CacheService` | Cache cart response: `cart:user:{user_id}` TTL 86400s |
 
 ---
 
 ## Business Logic Notes
-- `price_snapshot`: simpan harga saat item ditambahkan — harga produk bisa berubah tapi snapshot tetap
-- Cart item qty tidak boleh melebihi stok produk saat ini
-- Guest cart: simpan di Redis dengan session key, merge ke user cart saat login
-- Multi-store grouping: di-handle di `CartService::groupByStore()` saat checkout, bukan di DB
-- Wishlist item: tidak ada batas jumlah, tapi produk yang sama tidak bisa ditambah dua kali
+
+### Cart Lifecycle
+- Cart dibuat **otomatis** saat user pertama kali add item (tidak perlu endpoint create cart)
+- `Cart` adalah permanent record per user — tidak dihapus setelah checkout, hanya items-nya yang di-clear
+- Satu user satu cart (`unique('user_id')` di migration)
+
+### Add to Cart
+1. Cari atau buat `Cart` untuk user (`Cart::firstOrCreate(['user_id' => $user->id])`)
+2. Validasi variant: exists, product status `active`, stock tersedia
+3. Jika variant sudah ada di cart → increment quantity (bukan duplicate item)
+4. `price_snapshot` = `$variant->price` saat itu
+5. Denormalize `store_id = $variant->product->store_id`, `product_id = $variant->product_id`
+6. Invalidate Redis cache `cart:user:{user_id}`
+
+### Update Quantity
+- Validasi qty baru tidak melebihi `variant.stock` saat ini
+- Jika qty = 0 → hapus item (atau reject, tergantung UX preference) → **reject dengan 422**, suruh client pakai DELETE
+
+### Stock Validation Behavior
+- **Saat add/update:** blokir jika `qty > variant.stock` (422 + pesan "Stok tersedia: X")
+- **Saat checkout (Sprint 6):** re-validasi dengan `SELECT FOR UPDATE` untuk mencegah race condition. Jika stok tidak cukup → rollback + 422 "Stok {nama produk} tersisa {X}, ubah qty sebelum checkout"
+- **Tidak auto-adjust qty** — biarkan cart item tetap di qty lama, validasi hanya di entry points
+
+### Product Soft-Delete Handling
+Jika product di-soft-delete setelah ada di cart:
+- Cart item tetap ada di DB
+- `CartResource` tandai item dengan `is_available: false` + pesan "Produk tidak tersedia"
+- Tidak bisa di-checkout (filtered out di `groupByStore()`)
+
+### GroupByStore (untuk checkout — Sprint 6)
+```php
+// CartService::groupByStore(Cart $cart): array
+// Return: [store_id => ['store' => Store, 'items' => CartItem[]]]
+// Filter out items dengan is_available = false (product soft-deleted)
+// Pakai store_id yang sudah di-denormalize — tidak butuh join ke products
+```
+
+### Cart Response Shape
+```json
+{
+  "data": {
+    "total_items": 3,
+    "total_price_cents": 450000,
+    "total_price": "Rp 4.500",
+    "stores": [
+      {
+        "store_id": 1,
+        "store_name": "Toko A",
+        "store_slug": "toko-a",
+        "items": [
+          {
+            "id": 12,
+            "product_id": 5,
+            "product_name": "Sepatu Nike",
+            "product_slug": "sepatu-nike",
+            "variant_id": 8,
+            "variant_sku": "NK-RED-42",
+            "variant_attributes": {"warna": "Merah", "ukuran": "42"},
+            "quantity": 2,
+            "price_snapshot_cents": 150000,
+            "price_snapshot": "Rp 1.500",
+            "subtotal_cents": 300000,
+            "subtotal": "Rp 3.000",
+            "is_available": true,
+            "current_stock": 10,
+            "thumbnail_url": "https://..."
+          }
+        ],
+        "store_subtotal_cents": 300000,
+        "store_subtotal": "Rp 3.000"
+      }
+    ]
+  }
+}
+```
+
+### Wishlist
+- Satu user satu wishlist (auto-created on first add, seperti cart)
+- Produk yang sama tidak bisa ditambah dua kali (unique constraint `wishlist_id + product_id`)
+- Wishlist item simpan `product_id` (bukan variant) — buyer belum pilih ukuran/warna
+- `GET /api/wishlist` return produk dengan info terkini (nama, harga terbaru, stok, status)
+- Produk yang di-soft-delete tetap ada di wishlist tapi ditandai `is_available: false`
+
+### Welcome Email (carryover Sprint 1)
+```php
+// app/Listeners/Auth/SendWelcomeEmail.php
+class SendWelcomeEmail implements ShouldQueue {
+    public function handle(UserRegistered $event): void {
+        Mail::to($event->user)->send(new WelcomeMail($event->user));
+    }
+}
+// Register di AppServiceProvider::boot():
+// Event::listen(UserRegistered::class, SendWelcomeEmail::class);
+```
+
+---
+
+## Test Scenarios
+
+### CartTest (Feature)
+- `test_guest_cannot_access_cart`
+- `test_authenticated_user_can_add_item_to_cart`
+- `test_adding_same_variant_increments_quantity`
+- `test_cannot_add_item_exceeding_stock`
+- `test_cannot_add_inactive_product_to_cart`
+- `test_user_can_update_cart_item_quantity`
+- `test_update_quantity_to_zero_returns_422`
+- `test_user_can_remove_cart_item`
+- `test_user_can_clear_cart`
+- `test_cart_is_grouped_by_store`
+- `test_soft_deleted_product_marked_unavailable_in_cart`
+
+### WishlistTest (Feature)
+- `test_guest_cannot_access_wishlist`
+- `test_user_can_add_product_to_wishlist`
+- `test_cannot_add_same_product_twice_to_wishlist`
+- `test_user_can_remove_product_from_wishlist`
+- `test_wishlist_check_returns_true_if_product_wishlisted`
+- `test_wishlist_check_returns_false_if_not_wishlisted`
+- `test_product_detail_includes_is_wishlisted_when_authenticated`
+- `test_product_detail_omits_is_wishlisted_for_guest`
+
+### CartServiceTest (Unit)
+- `test_add_item_creates_cart_if_not_exists`
+- `test_add_item_increments_quantity_for_duplicate_variant`
+- `test_group_by_store_returns_correct_structure`
+- `test_group_by_store_excludes_unavailable_items`
+
+---
+
+## Checklist Eksekusi
+
+- [ ] Tambah `WelcomeMail` + `SendWelcomeEmail` listener (carryover Sprint 1)
+- [ ] Buat migrations (carts, cart_items dengan store_id+product_id, wishlists, wishlist_items)
+- [ ] Buat Models + Factories (Cart, CartItem, Wishlist, WishlistItem)
+- [ ] Buat `AddCartItemDTO`
+- [ ] Buat `CartService` dengan `add()`, `update()`, `remove()`, `clear()`, `groupByStore()`, `getForUser()` (DB + Redis cache)
+- [ ] Buat `WishlistService` dengan `add()`, `remove()`, `check()`, `getForUser()`
+- [ ] Update `ProductService::findBySlug()` terima optional `?User $user` → tambah `is_wishlisted` field
+- [ ] Buat Controllers + FormRequests + Resources
+- [ ] Buat routes/api/cart.php
+- [ ] Buat Feature Tests + Unit Tests
+- [ ] Update Postman collection (folder "06. Cart")
+- [ ] Update planning/05-cart.md → Status ✅ Selesai

--- a/planning/README.md
+++ b/planning/README.md
@@ -18,7 +18,7 @@
 | [02-user.md](./02-user.md) | User Profile | 🟠 P1 | ✅ |
 | [03-merchant.md](./03-merchant.md) | Merchant / Store | 🟠 P1 | ✅ |
 | [04-product.md](./04-product.md) | Product Catalog | 🟠 P1 | ✅ |
-| [05-cart.md](./05-cart.md) | Cart & Wishlist | 🟠 P1 | ⬜ |
+| [05-cart.md](./05-cart.md) | Cart & Wishlist | 🟠 P1 | 🟡 |
 | [06-order.md](./06-order.md) | Order Management | 🟠 P1 | ⬜ |
 | [07-payment.md](./07-payment.md) | Payment | 🟠 P1 | 🟡 |
 | [08-shipping.md](./08-shipping.md) | Shipping & Logistics | 🟠 P1 | ⬜ |

--- a/postman/marketplace_api.postman_collection.json
+++ b/postman/marketplace_api.postman_collection.json
@@ -3103,6 +3103,23 @@
                   "code": 200,
                   "body": "{\n  \"success\": true,\n  \"message\": \"Products retrieved.\",\n  \"data\": [\n    {\n      \"id\": 1, \"name\": \"Sepatu Lari\", \"slug\": \"sepatu-lari\", \"status\": \"active\",\n      \"min_price_cents\": 25000000, \"min_price\": \"Rp 250.000\",\n      \"max_price_cents\": 50000000, \"max_price\": \"Rp 500.000\",\n      \"total_stock\": 100, \"sold_count\": 0, \"rating_avg\": 0, \"thumbnail\": null,\n      \"store\": { \"id\": 1, \"name\": \"Toko Keren\", \"slug\": \"toko-keren\" },\n      \"category\": { \"id\": 2, \"name\": \"Olahraga\", \"slug\": \"olahraga\" },\n      \"created_at\": \"2026-05-08T00:00:00.000000Z\"\n    }\n  ],\n  \"meta\": { \"timestamp\": \"2026-05-08T00:00:00.000000Z\", \"pagination\": { \"current_page\": 1, \"last_page\": 1, \"per_page\": 20, \"total\": 1 } }\n}"
                 }
+              ],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "if (pm.response.code === 200) {",
+                      "  const body = pm.response.json();",
+                      "  if (body.data && body.data.length > 0) {",
+                      "    pm.collectionVariables.set('product_slug', body.data[0].slug);",
+                      "    pm.collectionVariables.set('wishlist_product_id', body.data[0].id);",
+                      "  }",
+                      "}"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
               ]
             },
             {
@@ -3111,15 +3128,18 @@
                 {
                   "listen": "test",
                   "script": {
-                    "type": "text/javascript",
                     "exec": [
                       "if (pm.response.code === 200) {",
                       "  const body = pm.response.json();",
                       "  if (body.data && body.data.slug) {",
                       "    pm.collectionVariables.set('product_slug', body.data.slug);",
                       "  }",
+                      "  if (body.data && body.data.id) {",
+                      "    pm.collectionVariables.set('wishlist_product_id', body.data.id);",
+                      "  }",
                       "}"
-                    ]
+                    ],
+                    "type": "text/javascript"
                   }
                 }
               ],
@@ -4157,7 +4177,7 @@
                     "items"
                   ]
                 },
-                "description": "Add a product to wishlist. product_id not variant_id \u2014 buyer hasn't chosen size/color yet.",
+                "description": "Add a product to wishlist.\n\n`product_id` (bukan variant_id) \u2014 buyer belum pilih ukuran/warna.\n\n**`{{wishlist_product_id}}`** otomatis terisi saat:\n- `GET /api/products` (List Products) \u2192 ambil produk pertama\n- `GET /api/products/{slug}` (Get Product Detail) \u2192 ambil produk yang sedang dilihat",
                 "body": {
                   "mode": "raw",
                   "raw": "{\n  \"product_id\": \"{{wishlist_product_id}}\"\n}",

--- a/postman/marketplace_api.postman_collection.json
+++ b/postman/marketplace_api.postman_collection.json
@@ -120,6 +120,16 @@
       "key": "category_slug",
       "value": "elektronik",
       "type": "string"
+    },
+    {
+      "key": "cart_item_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "wishlist_product_id",
+      "value": "",
+      "type": "string"
     }
   ],
   "auth": {
@@ -3760,6 +3770,521 @@
                   "status": "No Content",
                   "code": 204,
                   "body": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "06. Cart",
+      "item": [
+        {
+          "name": "Cart",
+          "item": [
+            {
+              "name": "[GET] Get Cart \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/cart",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "cart"
+                  ]
+                },
+                "description": "Returns cart grouped by store. Requires auth."
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 200\", () => pm.response.to.have.status(200));",
+                      "pm.test(\"Has stores array\", () => {",
+                      "    const j = pm.response.json();",
+                      "    pm.expect(j.data).to.have.property('stores');",
+                      "    pm.expect(j.data.stores).to.be.an('array');",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[POST] Add Item to Cart \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/cart/items",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "cart",
+                    "items"
+                  ]
+                },
+                "description": "Add a product variant to cart. Increments quantity if variant already in cart.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"variant_id\": \"{{variant_id}}\",\n  \"quantity\": 1\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "response": [
+                {
+                  "name": "201 \u2014 Item Added",
+                  "originalRequest": {},
+                  "status": "Created",
+                  "code": 201,
+                  "_postman_previewlanguage": "json",
+                  "body": "{\n  \"success\": true,\n  \"message\": \"Item added to cart.\",\n  \"data\": {\n    \"total_items\": 2,\n    \"total_price_cents\": 300000,\n    \"total_price\": \"Rp 3.000\",\n    \"stores\": [\n      {\n        \"store_id\": 1,\n        \"store_name\": \"Toko A\",\n        \"store_slug\": \"toko-a\",\n        \"items\": [\n          {\n            \"id\": 12,\n            \"product_id\": 5,\n            \"product_name\": \"Sepatu Nike\",\n            \"product_slug\": \"sepatu-nike\",\n            \"variant_id\": 8,\n            \"variant_sku\": \"NK-RED-42\",\n            \"variant_attributes\": {\n              \"warna\": \"Merah\",\n              \"ukuran\": \"42\"\n            },\n            \"quantity\": 2,\n            \"price_snapshot_cents\": 150000,\n            \"price_snapshot\": \"Rp 1.500\",\n            \"subtotal_cents\": 300000,\n            \"subtotal\": \"Rp 3.000\",\n            \"current_stock\": 10,\n            \"is_available\": true,\n            \"unavailable_reason\": null,\n            \"thumbnail_url\": null\n          }\n        ],\n        \"store_subtotal_cents\": 300000,\n        \"store_subtotal\": \"Rp 3.000\"\n      }\n    ]\n  },\n  \"meta\": {\n    \"timestamp\": \"2026-05-07T12:00:00Z\"\n  }\n}"
+                },
+                {
+                  "name": "422 \u2014 Stock Exceeded",
+                  "originalRequest": {},
+                  "status": "Unprocessable Entity",
+                  "code": 422,
+                  "_postman_previewlanguage": "json",
+                  "body": "{\n  \"success\": false,\n  \"message\": \"Stok tersedia: 3\",\n  \"meta\": {\n    \"timestamp\": \"2026-05-07T12:00:00Z\"\n  }\n}"
+                }
+              ],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 201\", () => pm.response.to.have.status(201));",
+                      "pm.test(\"Cart has items\", () => {",
+                      "    const j = pm.response.json();",
+                      "    pm.expect(j.data.total_items).to.be.above(0);",
+                      "    // Save first cart item id for update/delete tests",
+                      "    if (j.data.stores && j.data.stores[0] && j.data.stores[0].items[0]) {",
+                      "        pm.collectionVariables.set('cart_item_id', j.data.stores[0].items[0].id);",
+                      "    }",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[PUT] Update Cart Item Qty \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/cart/items/{{cart_item_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "cart",
+                    "items",
+                    "{{cart_item_id}}"
+                  ]
+                },
+                "description": "Update quantity of a specific cart item. Min 1 \u2014 use DELETE to remove.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"quantity\": 3\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 200\", () => pm.response.to.have.status(200));"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[DELETE] Remove Cart Item \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/cart/items/{{cart_item_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "cart",
+                    "items",
+                    "{{cart_item_id}}"
+                  ]
+                },
+                "description": "Remove a single item from cart."
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 200\", () => pm.response.to.have.status(200));"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[DELETE] Clear Cart \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/cart",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "cart"
+                  ]
+                },
+                "description": "Remove ALL items from cart. Called after checkout."
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 204\", () => pm.response.to.have.status(204));"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Wishlist",
+          "item": [
+            {
+              "name": "[GET] Get Wishlist \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/wishlist",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "wishlist"
+                  ]
+                },
+                "description": "Returns all wishlisted products with current price/stock/availability."
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 200\", () => pm.response.to.have.status(200));",
+                      "pm.test(\"Has items array\", () => {",
+                      "    pm.expect(pm.response.json().data).to.have.property('items');",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[POST] Add to Wishlist \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/wishlist/items",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "wishlist",
+                    "items"
+                  ]
+                },
+                "description": "Add a product to wishlist. product_id not variant_id \u2014 buyer hasn't chosen size/color yet.",
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"product_id\": \"{{wishlist_product_id}}\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                }
+              },
+              "response": [
+                {
+                  "name": "422 \u2014 Already Wishlisted",
+                  "originalRequest": {},
+                  "status": "Unprocessable Entity",
+                  "code": 422,
+                  "_postman_previewlanguage": "json",
+                  "body": "{\n  \"success\": false,\n  \"message\": \"Product is already in your wishlist.\",\n  \"meta\": {\n    \"timestamp\": \"2026-05-07T12:00:00Z\"\n  }\n}"
+                }
+              ],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 201\", () => pm.response.to.have.status(201));"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[DELETE] Remove from Wishlist \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/wishlist/items/{{wishlist_product_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "wishlist",
+                    "items",
+                    "{{wishlist_product_id}}"
+                  ]
+                },
+                "description": "Remove a product from wishlist by product_id (not item_id)."
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 204\", () => pm.response.to.have.status(204));"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "[GET] Check Wishlist Status \ud83d\udd12",
+              "request": {
+                "auth": {
+                  "type": "bearer",
+                  "bearer": [
+                    {
+                      "key": "token",
+                      "value": "{{access_token}}",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Accept",
+                    "value": "application/json"
+                  }
+                ],
+                "url": {
+                  "raw": "{{base_url}}/api/wishlist/items/{{wishlist_product_id}}/check",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "wishlist",
+                    "items",
+                    "{{wishlist_product_id}}",
+                    "check"
+                  ]
+                },
+                "description": "Quick check if a product is in user's wishlist. Used for UI toggle button."
+              },
+              "response": [],
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "pm.test(\"Status 200\", () => pm.response.to.have.status(200));",
+                      "pm.test(\"Has is_wishlisted field\", () => {",
+                      "    pm.expect(pm.response.json().data).to.have.property('is_wishlisted');",
+                      "});"
+                    ],
+                    "type": "text/javascript"
+                  }
                 }
               ]
             }

--- a/resources/views/emails/auth/welcome.blade.php
+++ b/resources/views/emails/auth/welcome.blade.php
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <h1>Welcome to Marketplace, {{ $user->name }}!</h1>
+    <p>Your account has been created successfully.</p>
+    <p>Start shopping or register your store today.</p>
+</body>
+</html>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,5 @@
 <?php
 
-foreach (['auth', 'user', 'merchant', 'product', 'payment', 'media'] as $domain) {
+foreach (['auth', 'user', 'merchant', 'product', 'cart', 'payment', 'media'] as $domain) {
     require __DIR__."/api/{$domain}.php";
 }

--- a/routes/api/cart.php
+++ b/routes/api/cart.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Http\Controllers\Api\Cart\CartController;
+use App\Http\Controllers\Api\Cart\WishlistController;
+use Illuminate\Support\Facades\Route;
+
+Route::middleware('auth:sanctum')->group(function () {
+
+    // Cart
+    Route::prefix('cart')->name('cart.')->group(function () {
+        Route::get('/', [CartController::class, 'index'])->name('index');
+        Route::post('/items', [CartController::class, 'store'])->name('items.store');
+        Route::put('/items/{cartItem}', [CartController::class, 'update'])->name('items.update');
+        Route::delete('/items/{cartItem}', [CartController::class, 'destroy'])->name('items.destroy');
+        Route::delete('/', [CartController::class, 'clear'])->name('clear');
+    });
+
+    // Wishlist
+    Route::prefix('wishlist')->name('wishlist.')->group(function () {
+        Route::get('/', [WishlistController::class, 'index'])->name('index');
+        Route::post('/items', [WishlistController::class, 'store'])->name('items.store');
+        Route::delete('/items/{productId}', [WishlistController::class, 'destroy'])->name('items.destroy');
+        Route::get('/items/{productId}/check', [WishlistController::class, 'check'])->name('items.check');
+    });
+});

--- a/tests/Feature/Api/Cart/CartTest.php
+++ b/tests/Feature/Api/Cart/CartTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature\Api\Cart;
+
+use App\Enums\ProductStatus;
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        return User::factory()->create();
+    }
+
+    private function activeVariant(int $stock = 10): ProductVariant
+    {
+        $store   = Store::factory()->create();
+        $product = Product::factory()->for($store)->create(['status' => ProductStatus::Active]);
+        return ProductVariant::factory()->for($product)->create(['stock' => $stock, 'price' => 150000]);
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    public function test_guest_cannot_access_cart(): void
+    {
+        $this->getJson('/api/cart')->assertStatus(401);
+    }
+
+    // ── Add to Cart ───────────────────────────────────────────────────────────
+
+    public function test_authenticated_user_can_add_item_to_cart(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant();
+
+        $this->actingAs($user)
+            ->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 2])
+            ->assertStatus(201)
+            ->assertJsonStructure(['data' => ['total_items', 'total_price_cents', 'stores']]);
+
+        $this->assertDatabaseHas('cart_items', [
+            'product_variant_id' => $variant->id,
+            'quantity'           => 2,
+        ]);
+    }
+
+    public function test_adding_same_variant_increments_quantity(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant(20);
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 2]);
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 3]);
+
+        $this->assertDatabaseHas('cart_items', [
+            'product_variant_id' => $variant->id,
+            'quantity'           => 5,
+        ]);
+        $this->assertEquals(1, CartItem::where('product_variant_id', $variant->id)->count());
+    }
+
+    public function test_cannot_add_item_exceeding_stock(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant(3);
+
+        $this->actingAs($user)
+            ->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 5])
+            ->assertStatus(422);
+    }
+
+    public function test_cannot_add_inactive_product_to_cart(): void
+    {
+        $user    = $this->actingUser();
+        $store   = Store::factory()->create();
+        $product = Product::factory()->for($store)->create(['status' => ProductStatus::Draft]);
+        $variant = ProductVariant::factory()->for($product)->create(['stock' => 10, 'price' => 100000]);
+
+        $this->actingAs($user)
+            ->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 1])
+            ->assertStatus(422);
+    }
+
+    // ── Update ────────────────────────────────────────────────────────────────
+
+    public function test_user_can_update_cart_item_quantity(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant(10);
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 2]);
+        $item = CartItem::where('product_variant_id', $variant->id)->first();
+
+        $this->actingAs($user)
+            ->putJson("/api/cart/items/{$item->id}", ['quantity' => 4])
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('cart_items', ['id' => $item->id, 'quantity' => 4]);
+    }
+
+    public function test_update_quantity_to_zero_returns_422(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant();
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 2]);
+        $item = CartItem::where('product_variant_id', $variant->id)->first();
+
+        $this->actingAs($user)
+            ->putJson("/api/cart/items/{$item->id}", ['quantity' => 0])
+            ->assertStatus(422);
+    }
+
+    // ── Remove ────────────────────────────────────────────────────────────────
+
+    public function test_user_can_remove_cart_item(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant();
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 1]);
+        $item = CartItem::where('product_variant_id', $variant->id)->first();
+
+        $this->actingAs($user)
+            ->deleteJson("/api/cart/items/{$item->id}")
+            ->assertStatus(200);
+
+        $this->assertDatabaseMissing('cart_items', ['id' => $item->id]);
+    }
+
+    public function test_user_can_clear_cart(): void
+    {
+        $user     = $this->actingUser();
+        $variant1 = $this->activeVariant();
+        $variant2 = $this->activeVariant();
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant1->id, 'quantity' => 1]);
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant2->id, 'quantity' => 1]);
+
+        $cart = Cart::where('user_id', $user->id)->first();
+        $this->assertEquals(2, $cart->items()->count());
+
+        $this->actingAs($user)
+            ->deleteJson('/api/cart')
+            ->assertStatus(204);
+
+        $this->assertEquals(0, $cart->fresh()->items()->count());
+    }
+
+    // ── Grouping ──────────────────────────────────────────────────────────────
+
+    public function test_cart_is_grouped_by_store(): void
+    {
+        $user     = $this->actingUser();
+        $variant1 = $this->activeVariant();
+        $variant2 = $this->activeVariant();
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant1->id, 'quantity' => 1]);
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant2->id, 'quantity' => 1]);
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/cart')
+            ->assertStatus(200);
+
+        $stores = $response->json('data.stores');
+        $this->assertCount(2, $stores);
+    }
+
+    // ── Soft-deleted product ──────────────────────────────────────────────────
+
+    public function test_soft_deleted_product_marked_unavailable_in_cart(): void
+    {
+        $user    = $this->actingUser();
+        $variant = $this->activeVariant();
+
+        $this->actingAs($user)->postJson('/api/cart/items', ['variant_id' => $variant->id, 'quantity' => 1]);
+
+        $variant->product->delete();
+
+        $response = $this->actingAs($user)
+            ->getJson('/api/cart')
+            ->assertStatus(200);
+
+        $item = $response->json('data.stores.0.items.0');
+        $this->assertFalse($item['is_available']);
+        $this->assertNotNull($item['unavailable_reason']);
+    }
+}

--- a/tests/Feature/Api/Cart/WishlistTest.php
+++ b/tests/Feature/Api/Cart/WishlistTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Api\Cart;
+
+use App\Enums\ProductStatus;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\User;
+use App\Models\Wishlist;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WishlistTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingUser(): User
+    {
+        return User::factory()->create();
+    }
+
+    private function activeProduct(): Product
+    {
+        $store = Store::factory()->create();
+        return Product::factory()->for($store)->create(['status' => ProductStatus::Active]);
+    }
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+
+    public function test_guest_cannot_access_wishlist(): void
+    {
+        $this->getJson('/api/wishlist')->assertStatus(401);
+    }
+
+    // ── Add ───────────────────────────────────────────────────────────────────
+
+    public function test_user_can_add_product_to_wishlist(): void
+    {
+        $user    = $this->actingUser();
+        $product = $this->activeProduct();
+
+        $this->actingAs($user)
+            ->postJson('/api/wishlist/items', ['product_id' => $product->id])
+            ->assertStatus(201)
+            ->assertJsonStructure(['data' => ['total', 'items']]);
+
+        $this->assertDatabaseHas('wishlist_items', ['product_id' => $product->id]);
+    }
+
+    public function test_cannot_add_same_product_twice_to_wishlist(): void
+    {
+        $user    = $this->actingUser();
+        $product = $this->activeProduct();
+
+        $this->actingAs($user)->postJson('/api/wishlist/items', ['product_id' => $product->id]);
+
+        $this->actingAs($user)
+            ->postJson('/api/wishlist/items', ['product_id' => $product->id])
+            ->assertStatus(422);
+    }
+
+    // ── Remove ────────────────────────────────────────────────────────────────
+
+    public function test_user_can_remove_product_from_wishlist(): void
+    {
+        $user    = $this->actingUser();
+        $product = $this->activeProduct();
+
+        $this->actingAs($user)->postJson('/api/wishlist/items', ['product_id' => $product->id]);
+
+        $this->actingAs($user)
+            ->deleteJson("/api/wishlist/items/{$product->id}")
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('wishlist_items', ['product_id' => $product->id]);
+    }
+
+    // ── Check ─────────────────────────────────────────────────────────────────
+
+    public function test_wishlist_check_returns_true_if_product_wishlisted(): void
+    {
+        $user    = $this->actingUser();
+        $product = $this->activeProduct();
+
+        $this->actingAs($user)->postJson('/api/wishlist/items', ['product_id' => $product->id]);
+
+        $this->actingAs($user)
+            ->getJson("/api/wishlist/items/{$product->id}/check")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_wishlisted', true);
+    }
+
+    public function test_wishlist_check_returns_false_if_not_wishlisted(): void
+    {
+        $user    = $this->actingUser();
+        $product = $this->activeProduct();
+
+        $this->actingAs($user)
+            ->getJson("/api/wishlist/items/{$product->id}/check")
+            ->assertStatus(200)
+            ->assertJsonPath('data.is_wishlisted', false);
+    }
+
+    // ── Product detail integration ────────────────────────────────────────────
+
+    public function test_product_detail_includes_is_wishlisted_when_authenticated(): void
+    {
+        $user    = $this->actingUser();
+        $product = $this->activeProduct();
+
+        $this->actingAs($user)->postJson('/api/wishlist/items', ['product_id' => $product->id]);
+
+        $response = $this->actingAs($user)
+            ->getJson("/api/products/{$product->slug}")
+            ->assertStatus(200);
+
+        $this->assertTrue($response->json('data.is_wishlisted'));
+    }
+
+    public function test_product_detail_omits_is_wishlisted_for_guest(): void
+    {
+        $product = $this->activeProduct();
+
+        $response = $this->getJson("/api/products/{$product->slug}")
+            ->assertStatus(200);
+
+        $this->assertArrayNotHasKey('is_wishlisted', $response->json('data'));
+    }
+}

--- a/tests/Unit/Services/Cart/CartServiceTest.php
+++ b/tests/Unit/Services/Cart/CartServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Services\Cart;
+
+use App\Enums\ProductStatus;
+use App\Models\Cart;
+use App\Models\CartItem;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\Store;
+use App\Models\User;
+use App\Services\Cart\CartService;
+use App\DTOs\Cart\AddCartItemDTO;
+use App\Contracts\Shared\CacheServiceInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CartServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private CartService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $cache = $this->mock(CacheServiceInterface::class, function ($mock) {
+            $mock->shouldReceive('remember')->andReturnUsing(fn ($key, $ttl, $cb) => $cb());
+            $mock->shouldReceive('forget')->andReturn(true);
+        });
+
+        $this->service = new CartService($cache);
+    }
+
+    private function makeActiveVariant(int $stock = 10): ProductVariant
+    {
+        $store   = Store::factory()->create();
+        $product = Product::factory()->for($store)->create(['status' => ProductStatus::Active]);
+        return ProductVariant::factory()->for($product)->create(['stock' => $stock, 'price' => 100000]);
+    }
+
+    public function test_add_item_creates_cart_if_not_exists(): void
+    {
+        $user    = User::factory()->create();
+        $variant = $this->makeActiveVariant();
+
+        $this->assertDatabaseMissing('carts', ['user_id' => $user->id]);
+
+        $this->service->add($user, new AddCartItemDTO($variant->id, 1));
+
+        $this->assertDatabaseHas('carts', ['user_id' => $user->id]);
+    }
+
+    public function test_add_item_increments_quantity_for_duplicate_variant(): void
+    {
+        $user    = User::factory()->create();
+        $variant = $this->makeActiveVariant(20);
+
+        $this->service->add($user, new AddCartItemDTO($variant->id, 2));
+        $this->service->add($user, new AddCartItemDTO($variant->id, 3));
+
+        $this->assertEquals(1, CartItem::where('product_variant_id', $variant->id)->count());
+        $this->assertEquals(5, CartItem::where('product_variant_id', $variant->id)->value('quantity'));
+    }
+
+    public function test_group_by_store_returns_correct_structure(): void
+    {
+        $user     = User::factory()->create();
+        $variant1 = $this->makeActiveVariant();
+        $variant2 = $this->makeActiveVariant();
+
+        $this->service->add($user, new AddCartItemDTO($variant1->id, 1));
+        $this->service->add($user, new AddCartItemDTO($variant2->id, 1));
+
+        $cart   = Cart::with('items.variant.product', 'items.store')->where('user_id', $user->id)->first();
+        $groups = $this->service->groupByStore($cart);
+
+        $this->assertCount(2, $groups);
+        foreach ($groups as $group) {
+            $this->assertArrayHasKey('store', $group);
+            $this->assertArrayHasKey('items', $group);
+            $this->assertNotEmpty($group['items']);
+        }
+    }
+
+    public function test_group_by_store_excludes_unavailable_items(): void
+    {
+        $user    = User::factory()->create();
+        $variant = $this->makeActiveVariant();
+
+        $this->service->add($user, new AddCartItemDTO($variant->id, 1));
+
+        $variant->product->delete();
+
+        $cart   = Cart::with(['items.variant.product', 'items.store'])->where('user_id', $user->id)->first();
+        $groups = $this->service->groupByStore($cart);
+
+        foreach ($groups as $group) {
+            foreach ($group['items'] as $itemData) {
+                $this->assertFalse($itemData['is_available']);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Cart module**: Add/update/remove items, multi-store grouping, Redis cache + DB source of truth
- **Wishlist module**: Add/remove/check per product, `is_wishlisted` injected into product detail when authenticated
- **WelcomeMail**: Carryover from Sprint 1 — fires on `UserRegistered` event via queued listener
- **DomainException → 422**: Added global handler in `bootstrap/app.php` for business rule violations

## What's included

| Layer | Files |
|---|---|
| Migrations | `carts`, `cart_items` (denorm `store_id`+`product_id`), `wishlists`, `wishlist_items` |
| Models + Factories | `Cart`, `CartItem`, `Wishlist`, `WishlistItem` |
| DTOs | `AddCartItemDTO` |
| Services | `CartService`, `WishlistService` |
| Controllers | `CartController`, `WishlistController` |
| Form Requests | `AddCartItemRequest`, `UpdateCartItemRequest` |
| Resources | `CartResource`, `CartItemResource`, `WishlistResource`, `WishlistItemResource` |
| Routes | `routes/api/cart.php` |
| Tests | 11 CartTest + 8 WishlistTest + 4 CartServiceTest |

## Key design decisions

- **DB source of truth + Redis cache**: Cart record cached, relationships always loaded fresh (prevents stale availability data on product soft-delete)
- **Soft-deleted products**: Loaded via `withTrashed()`, marked `is_available: false` in response
- **Grouped by store**: Denormalized `store_id` in `cart_items` avoids extra join at render
- **Quantity increment**: Adding same variant increments quantity, not duplicate item

## Test plan

- [x] Guest cannot access cart/wishlist (401)
- [x] Add item, increment same variant, stock validation, inactive product blocked
- [x] Update qty / remove item / clear cart
- [x] Soft-deleted product marked unavailable
- [x] Wishlist CRUD + check endpoint
- [x] `is_wishlisted` in product detail for auth users, absent for guests
- [x] Full suite: 226 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)