### PR TITLE
chore(rules): add Sprint Execution Workflow + slash commands

### DIFF
--- a/.claude/commands/execute.md
+++ b/.claude/commands/execute.md
@@ -1,0 +1,63 @@
+---
+description: Execute a sprint/module — create GitHub issue, branch from main, implement the FULL module per planning doc, then STOP for user review. Do not push without explicit /push command.
+---
+
+Execute the module: $ARGUMENTS
+
+Follow the **Sprint Execution Workflow** from `CLAUDE.md`. Treat the planning doc as the source of truth.
+
+## Pre-flight Checks
+
+1. Verify `planning/{NN}-{module}.md` exists. Fail clearly if not.
+2. Verify working tree is clean (`git status` — no uncommitted changes). If dirty, ask user how to proceed.
+3. Verify current branch is `main` or ask user before continuing.
+
+## Setup
+
+4. Create GitHub issue via `gh issue create`:
+   - Title: `Sprint {N}: {Module Name}`
+   - Body: Link to planning doc + 3-5 bullet scope summary
+   - Label: none (project doesn't use labels yet)
+5. `git checkout main && git pull origin main`
+6. Create branch: `git checkout -b feat/sprint-{N}-{module-slug}`
+   - Use the number from the planning filename (e.g. `06-order` → `feat/sprint-6-order`)
+
+## Implementation
+
+7. Implement the **FULL module** according to the planning doc — all phases at once.
+   - Follow ALL Architecture Rules in CLAUDE.md (thin controllers, fat services, DTOs, ApiResponse, etc.)
+   - Follow Naming Conventions strictly
+   - Follow Testing Standards (RefreshDatabase, assertJsonStructure, explicit HTTP status)
+8. Make **atomic local commits** per logical unit:
+   - `feat({domain}): enums + migrations`
+   - `feat({domain}): models + factories + DTOs`
+   - `feat({domain}): service + events + listeners + jobs`
+   - `feat({domain}): controllers + requests + resources + routes`
+   - `feat({domain}): feature tests`
+   - `feat({domain}): postman + seeder + planning checkboxes`
+9. **DO NOT push to remote.**
+
+## Definition of Done (all required before STOP)
+
+10. **Tests**: `docker compose exec app php artisan test` — all tests pass.
+11. **Postman**: edit `postman/{NN}-{module}.postman_collection.json` (add all new endpoints with auth, examples, and test scripts) → run `python3 postman/merge.py`.
+12. **Planning doc**: open `planning/{NN}-{module}.md`, tick `⬜` → `✅` for completed items, set status to `✅ Selesai`.
+13. **DevSeeder**: if there are new entities, add sample data to `database/seeders/DevSeeder.php` for `test@example.com`.
+
+## Stop and Self-Review
+
+14. Emit **Self-Review Report** in the exact format defined in CLAUDE.md section "Self-Review Report Format":
+    - Files Changed (categorized)
+    - Tests (pass/fail/skipped + duration)
+    - New Endpoints in Postman
+    - Potential Issues / Known Gaps (be honest — flag race conditions, stubs, untested paths)
+    - Pending Dependencies for Future Sprints
+    - Done Criteria Status checklist
+15. **STOP.** Wait for user to run `/push`.
+
+## Rules
+
+- **No push, no PR, no merge** without explicit user command.
+- If a bug is found during execution, fix it inline in the same branch (no separate branch).
+- If `main` advances during work, rebase the feature branch and report any conflicts that need user decision.
+- If tests fail, fix the underlying issue — do not skip or disable tests.

--- a/.claude/commands/merge-ok.md
+++ b/.claude/commands/merge-ok.md
@@ -1,0 +1,46 @@
+---
+description: User has reviewed and approved the PR — merge to main with squash and delete the branch. Also updates project_state.md memory.
+---
+
+User has approved the PR. Merge it to main: $ARGUMENTS
+
+## Identify PR Number
+
+1. If `$ARGUMENTS` provides a PR number, use that.
+2. Otherwise, run `gh pr list --head $(git branch --show-current) --json number,title,state --jq '.[0]'` to get the PR for the current branch.
+3. Fail clearly if no PR is found or if the PR is not in `OPEN` state.
+
+## Pre-merge Checks
+
+4. Verify PR is mergeable: `gh pr view {N} --json mergeable,state`
+   - If `CONFLICTING`, report conflict and stop.
+   - If `state` is not `OPEN`, stop (already merged or closed).
+5. Optionally check CI status: `gh pr checks {N}` — warn user if checks are failing but proceed if user explicitly invoked `/merge-ok` anyway.
+
+## Merge
+
+6. Run `gh pr merge {N} --squash --delete-branch`.
+7. Switch back to main: `git checkout main && git pull origin main`.
+8. Confirm merge in logs: `git log --oneline -3`.
+
+## Update Memory
+
+9. Update `memory/project_state.md` (if Sprint work):
+   - Mark the sprint as `COMPLETE ✅ MERGED`
+   - Update "Next" pointer to the next sprint
+   - Note any pending dependencies discovered during review
+
+## Report
+
+10. Return summary:
+    - PR # and title that was merged
+    - Commit SHA on main after merge
+    - Branch deleted (yes/no)
+    - Next suggested step
+
+## Rules
+
+- **Always squash** — keep main history clean.
+- **Always delete branch** — no stale feature branches.
+- **Never force-merge** — if CI/checks fail and user wants to proceed anyway, require explicit confirmation.
+- Never bypass approval — `/merge-ok` IS the approval; never auto-merge from `/pr` or anywhere else.

--- a/.claude/commands/plan-review.md
+++ b/.claude/commands/plan-review.md
@@ -1,0 +1,33 @@
+---
+description: Review and discuss the planning document for a module/sprint. Read-only — no code changes, no git operations.
+---
+
+Review the planning document for: $ARGUMENTS
+
+## Steps
+
+1. Locate the planning file at `planning/{NN}-{module}.md` based on the argument.
+   - Argument format: `06-order`, `7-payment`, or `sprint-7`
+   - Fail with a clear message if the file doesn't exist.
+2. Read the **full** planning document.
+3. Summarize for the user:
+   - **Scope**: what's being built (1-2 sentences)
+   - **Entities**: tables + key columns
+   - **Endpoints**: route list
+   - **Dependencies**: services that must already exist (mis: `OrderService`, `EmailService`)
+   - **State machine / Business rules**: if any
+4. Flag any **ambiguities, contradictions, or gaps**:
+   - Missing field types or migration column specs
+   - Unclear error scenarios
+   - Implicit assumptions about other sprints
+   - Conflict between sections of the same planning doc
+5. Ask clarifying questions if needed — use `AskUserQuestion` for binary/multi-choice questions.
+
+## Rules
+
+- **DO NOT modify any code files.**
+- **DO NOT create branches, issues, or commits.**
+- **DO NOT run tests or seeders.**
+- This is a planning discussion only.
+
+Execution starts only when user invokes `/execute {module}`.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,42 @@
+---
+description: Create a Pull Request from the current branch to main using gh CLI. Generates title and body from commits and diff.
+---
+
+Create a Pull Request for the current branch.
+
+## Pre-flight Checks
+
+1. Verify current branch is **not** `main`.
+2. Verify the branch is already pushed to remote (`git ls-remote --heads origin {current-branch}`). If not, ask user to run `/push` first.
+3. Check if a PR already exists for this branch (`gh pr list --head {current-branch}`). If yes, return its URL and stop.
+
+## Gather Context
+
+4. Run in parallel:
+   - `git log main..HEAD --oneline` — commits ahead of main
+   - `git diff main..HEAD --stat` — file change stats
+   - `git diff main..HEAD --name-only` — full file list
+5. Analyze ALL commits (not just the latest) to understand the full scope of the PR.
+
+## Draft PR Body
+
+6. Title: `feat({domain}): Sprint {N} — {Module Name}` for sprint work, or `chore({scope}): {short description}` for meta-changes.
+7. Body sections (skip empty ones):
+   - **Summary** — 3-5 bullets on what was added/changed
+   - **Bug Fixes** — list any bugs fixed during execution
+   - **Endpoints** — list new endpoints if applicable
+   - **Test Plan** — markdown checkbox list (tests pass, Postman updated, etc.)
+   - **Notes** — pending dependencies for future sprints, stubs that need activation
+
+## Create PR
+
+8. Run `gh pr create --base main --head {current-branch}` with title and body via HEREDOC for correct formatting.
+9. Return the PR URL to the user.
+
+## Rules
+
+- Use HEREDOC for the body to preserve newlines and markdown formatting.
+- Title under 70 characters — use the body for details.
+- Don't push from this command — `/push` should already have been run.
+- After creating PR, suggest user run `/ultrareview {PR}` manually if they want automated multi-agent review.
+- Stop after creating PR — wait for `/merge-ok` before merging.

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,0 +1,17 @@
+---
+description: Push current branch to remote. Verifies branch is not main and reports the URL for creating a PR.
+---
+
+Push the current branch to remote.
+
+## Steps
+
+1. Verify current branch is **not** `main` (`git branch --show-current`). If on main, refuse and explain.
+2. Run `git push -u origin {current-branch}`.
+3. Report the push result and the GitHub URL for creating a PR (shown in the push output).
+
+## Notes
+
+- This command only pushes — it does NOT create a PR. Run `/pr` next to create the PR.
+- If the branch already has an upstream, plain `git push` is sufficient.
+- If the push fails due to non-fast-forward (remote has new commits), inform the user and ask whether to rebase or force-push (never force-push without explicit permission).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,9 +346,9 @@ public function process(CheckoutDTO $data): Order { ... }
 
 13. **Service Return Type.** Service harus mengembalikan Model, DTO, atau boolean. Gunakan **Exceptions** untuk alur error (misal: `InsufficientStockException`), jangan return `['error' => '...']`.
 
-14. **Git Workflow (PR-first).** DILARANG push langsung ke `main`. Selalu buat branch `feat/nama-fitur` atau `fix/nama-bug`. Setelah selesai, push ke remote dan buat Pull Request untuk review.
+14. **Sprint Execution Workflow.** Semua perubahan kode WAJIB mengikuti **Sprint Execution Workflow** — plan-first → `/execute` (issue + branch) → kerjakan modul → self-review report → STOP. Push, PR, dan merge HANYA via slash command user (`/push`, `/pr`, `/merge-ok`). Detail lengkap di section terpisah.
 
-15. **API Documentation.** Setiap penambahan endpoint WAJIB diiringi dengan: (1) update file collection domain-nya di `postman/{nn}-{domain}.postman_collection.json` — nomor prefix selaras dengan nomor modul di tabel Domain Modules; (2) jalankan `python3 postman/merge.py`; (3) commit keduanya bersama domain file. Lihat section **API Documentation (Postman)** untuk detail lengkap.
+15. **API Documentation.** Setiap penambahan endpoint WAJIB ditambah ke `postman/{nn}-{domain}.postman_collection.json` (nomor prefix selaras dengan tabel Domain Modules) dan `python3 postman/merge.py` dijalankan sebelum stop. Ini bagian dari **Definition of Done** modul (lihat Sprint Execution Workflow).
 
 
 ---
@@ -754,17 +754,165 @@ Follow this priority when a new feature is requested. Never skip an earlier-prio
 
 ---
 
-## Git & Contribution Workflow
+## Sprint Execution Workflow
 
-Selalu ikuti alur ini untuk menjaga integritas `main` branch:
+Alur kerja standar untuk setiap modul/sprint. **Semua perubahan kode WAJIB melalui flow ini.** User mengontrol setiap transisi via slash command — assistant tidak boleh push, buat PR, atau merge tanpa command eksplisit.
 
-1.  **Sync:** `git checkout main && git pull origin main`
-2.  **Branch:** `git checkout -b feat/feature-name` (Gunakan prefix `feat/`, `fix/`, `refactor/`, atau `chore/`)
-3.  **Code:** Lakukan perubahan dan commit secara atomik.
-4.  **Test:** Pastikan `php artisan test` lulus semua.
-5.  **Push:** `git push origin feat/feature-name`
-6.  **PR:** Buka Pull Request di GitHub. Berikan deskripsi perubahan dan lampirkan screenshot/recording jika ada perubahan UI/logic signifikan.
-7.  **Merge:** Dilakukan setelah review atau jika CI/CD lulus.
+### Slash Commands
+
+| Command | Aksi |
+|---|---|
+| `/plan-review {module}` | Diskusi planning dengan user. Baca `planning/NN-module.md`, klarifikasi kalau ambigu, **tidak modifikasi file kode** |
+| `/execute {module}` | Mulai eksekusi: buat GitHub issue → branch dari main → kerjakan modul → stop di akhir dengan self-review report |
+| `/push` | Push branch aktif ke remote |
+| `/pr` | Buat Pull Request ke main |
+| `/merge-ok` | User sudah review PR dan approve — assistant merge + delete branch |
+
+### Cycle Lengkap
+
+```
+1. /plan-review 07-payment
+   → Baca planning, klarifikasi kalau ambigu, no code changes
+
+2. /execute 07-payment
+   → gh issue create (link planning doc, scope ringkas)
+   → git checkout main && git pull
+   → git checkout -b feat/sprint-7-payment
+   → Kerjakan FULL modul (semua phase sekaligus)
+   → Commit lokal atomic per logical unit (NO push)
+   → Update Postman: postman/07-payment.postman_collection.json + jalankan merge.py
+   → Update planning/07-payment.md: centang checkbox + status ✅ Selesai
+   → Update DevSeeder kalau ada entity baru
+   → Pastikan php artisan test lulus
+   → Kirim self-review report (format di bawah)
+   → STOP — tunggu user review
+
+3. User review manual file-by-file di IDE
+
+4. /push
+   → git push -u origin feat/sprint-7-payment
+
+5. /pr
+   → gh pr create --base main --head feat/sprint-7-payment
+
+6. (Optional) /ultrareview {PR-number}
+   → User trigger sendiri di UI (assistant tidak bisa)
+
+7. /merge-ok
+   → gh pr merge {N} --squash --delete-branch
+   → Update memory/project_state.md
+```
+
+### Aturan Wajib
+
+1.  **Plan-first.** Dilarang eksekusi sebelum `/plan-review` dijalankan untuk modul tersebut, kecuali user eksplisit minta skip.
+2.  **Issue per modul.** `/execute` selalu diawali dengan `gh issue create` — link ke planning doc, deskripsi singkat scope.
+3.  **Branch dari main.** Selalu `git checkout main && git pull origin main` sebelum buat branch. Penamaan: `feat/sprint-N-{module}` untuk sprint/modul, `fix/{short-description}` untuk bug fix.
+4.  **Local commits OK, no push.** Selama eksekusi boleh commit atomic per logical unit (mis: `feat(order): enums + migrations`, `feat(order): service + events`). Push HANYA setelah `/push`.
+5.  **Definition of Done per modul** — sebelum stop dan minta review, harus selesai SEMUA:
+    - `php artisan test` lulus semua
+    - File Postman domain diupdate + `python3 postman/merge.py` dijalankan
+    - `planning/NN-module.md` — checkbox dicentang sesuai yang dikerjakan, status diubah ke `✅ Selesai`
+    - DevSeeder ditambah sample data untuk entity baru (jika ada)
+    - Self-review report dikirim ke user
+6.  **Tidak push tanpa command.** Assistant TIDAK BOLEH push ke remote, buat PR, atau merge tanpa user menjalankan `/push`, `/pr`, atau `/merge-ok`.
+7.  **Merge butuh approval.** `/merge-ok` adalah satu-satunya cara assistant merge ke main. Tanpa command itu, PR tetap open.
+8.  **Bug fix workflow.** Bug di luar konteks sprint butuh issue + branch terpisah `fix/...` + PR (workflow yang sama). Bug yang ditemukan SAAT eksekusi sprint difix langsung di branch sprint itu (inline).
+9.  **Conflict handling.** Kalau `main` advance saat assistant kerja di branch, assistant yang rebase. Lapor kalau ada conflict yang butuh keputusan user.
+
+### Meta-Change Workflow (Rules, Skills, Commands, Docs, Config)
+
+Untuk perubahan yang **BUKAN feature code** — rule (`CLAUDE.md`), `.claude/` config (skills, slash commands, agents), planning docs, Docker/ENV config, script utility (mis: `postman/merge.py`) — pakai alur ringan ini:
+
+```
+1. Branch dari main: chore/{short-description}
+   (mis: chore/sprint-workflow-rules, chore/update-postman-merge)
+2. Lakukan perubahan
+3. Commit lokal (no push)
+4. Short summary ke user (bukan full Self-Review Report)
+5. STOP — tunggu /push, /pr, /merge-ok
+```
+
+**Yang TIDAK perlu untuk meta-change:**
+- ❌ GitHub issue
+- ❌ `/plan-review` (tidak ada planning doc)
+- ❌ Test suite run (kecuali perubahan mempengaruhi test config)
+- ❌ Postman update
+- ❌ DevSeeder update
+- ❌ Full Self-Review Report
+
+**Tetap berlaku:**
+- ✅ Branch dari main (TIDAK BOLEH commit langsung ke main)
+- ✅ Tidak push tanpa `/push`
+- ✅ Tidak merge tanpa `/merge-ok`
+- ✅ PR untuk review user
+
+### Short Summary Format (Meta-Change)
+
+```markdown
+## 🔧 Meta-Change Summary — {branch name}
+
+**Scope:** {Rule update / Skill / Command / Config / Docs}
+
+**Changes:**
+- `path/to/file` — {what changed in 1 line}
+- ...
+
+**Rationale:** {1-2 sentences}
+
+Ready for review. Run `/push` to push, then `/pr` to create PR.
+```
+
+### Self-Review Report Format
+
+Saat stop di akhir modul, kirim report dengan format konsisten ini:
+
+```markdown
+## 🤖 Self-Review Report — {Sprint N: Module Name}
+
+### Files Changed ({total})
+
+- **Models** ({n}): `Order.php`, `OrderItem.php`, ...
+- **Migrations** ({n}): ...
+- **Enums/DTOs** ({n}): ...
+- **Services** ({n}): ...
+- **Controllers** ({n}): ...
+- **Requests** ({n}): ...
+- **Resources** ({n}): ...
+- **Events/Listeners** ({n}): ...
+- **Jobs/Commands** ({n}): ...
+- **Mails/Views** ({n}): ...
+- **Tests** ({n}): ...
+- **Routes** ({n}): ...
+- **Postman** ({n}): ...
+- **Other** ({n}): ...
+
+### Tests
+
+- {X} passed, {Y} failed, {Z} skipped — duration {T}s
+
+### New Endpoints in Postman
+
+- `{METHOD} {path}` — {short description}
+
+### Potential Issues / Known Gaps
+
+- **[severity]** {issue description + file:line}
+
+### Pending Dependencies for Future Sprints
+
+- {dependency note, e.g. "ProcessRefundIfPaid stub — aktif di Sprint N"}
+
+### Done Criteria Status
+
+- [x] Tests pass
+- [x] Postman updated + merge.py run
+- [x] Planning doc updated (✅ Selesai)
+- [x] DevSeeder updated (if applicable)
+- [x] Local commits atomic ({N} commits)
+
+**Ready for review.** Run `/push` to push to remote, then `/pr` to create PR.
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace generic "Git & Contribution Workflow" with **Sprint Execution Workflow** in `CLAUDE.md` — plan-first → `/execute` (issue + branch) → atomic local commits → Definition of Done → Self-Review Report → STOP
- Add **Meta-Change Workflow** section for non-feature changes (rules, skills, commands, docs, config) — lighter flow, no issue/planning/Postman/seeder required, but still branch + PR + approval gate
- Register 5 new slash commands in `.claude/commands/` so they appear in CLI palette: `/plan-review`, `/execute`, `/push`, `/pr`, `/merge-ok`
- Update Architecture Rule #14 → reference Sprint Execution Workflow
- Update Architecture Rule #15 → Postman update is part of Definition of Done

## Workflow Highlights

- **User controls every transition** — assistant cannot push, create PR, or merge without explicit slash command
- **`/merge-ok` is the only approval gate** — merge to main requires this command
- **Self-Review Report has a consistent template** documented in CLAUDE.md
- **Bug fix workflow** — same rigor as feature work (issue + branch + PR)

## Test Plan

- [x] All 5 slash commands appear in `/` palette (`plan-review`, `execute`, `push`, `pr`, `merge-ok`)
- [x] Architecture Rules #14 and #15 reference the new sections
- [x] Sprint Execution Workflow and Meta-Change Workflow sections are present in CLAUDE.md
- [ ] Manual review of workflow text (user reviews in IDE)

## Notes

- This PR itself was created using the Meta-Change Workflow it defines — branch `chore/sprint-workflow-rules`, no issue, no Postman/seeder updates, light Short Summary instead of full Self-Review Report.
- After merge, Sprint 7 (Payment) will be the first sprint to exercise the full new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)