### PR TITLE
fix(standards): API standards compliance pass — Rule 1, HTTP codes, CLAUDE.md

### DIFF
--- a/.claude/commands/api-audit.md
+++ b/.claude/commands/api-audit.md
@@ -38,35 +38,39 @@ class ApiResponse
         string $message,
         mixed $data = null,
         int $status = 200,
-        array $extraMeta = [],
+        array $paginationMeta = [],
     ): JsonResponse {
+        $meta = ['timestamp' => now()->toISOString()];
+
+        if (!empty($paginationMeta)) {
+            $meta['pagination'] = $paginationMeta;
+        }
+
         return response()->json([
             'success' => true,
             'message' => $message,
             'data'    => $data,
-            'meta'    => array_merge(['timestamp' => now()->toISOString()], $extraMeta),
+            'meta'    => $meta,
         ], $status);
     }
 
-    public static function error(
-        string $message,
-        int $status = 400,
-        array $errors = [],
-    ): JsonResponse {
-        $body = [
+    public static function error(string $message, int $status = 400): JsonResponse
+    {
+        return response()->json([
             'success' => false,
             'message' => $message,
             'meta'    => ['timestamp' => now()->toISOString()],
-        ];
-        if (!empty($errors)) {
-            $body['errors'] = $errors;
-        }
-        return response()->json($body, $status);
+        ], $status);
     }
 
     public static function validationError(string $message, array $errors): JsonResponse
     {
-        return self::error($message, 422, $errors);
+        return response()->json([
+            'success' => false,
+            'message' => $message,
+            'errors'  => $errors,
+            'meta'    => ['timestamp' => now()->toISOString()],
+        ], 422);
     }
 }
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ tests/
 
 ## API Response Standard
 
-Semua Controller WAJIB menggunakan `ApiResponse` trait. Format JSON harus konsisten:
+Semua Controller WAJIB menggunakan `ApiResponse` class (static methods). Format JSON harus konsisten:
 
 ### Success Response (200/201)
 ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ app/
 │   │   ├── LogApiRequests.php         # Global — audit + Grafana logging
 │   │   └── EnsureMerchantOwnership.php
 │   └── Responses/
-│       └── ApiResponse.php            # MANDATORY — all responses go through this
+│       └── ApiResponse.php            # MANDATORY class — all responses go through this
 │
 ├── Models/                            # All models in root — domain grouped by naming
 │   ├── User.php                       # [Auth/User]
@@ -186,7 +186,7 @@ app/
 │       └── CreateProductDTO.php
 │
 ├── Responses/                         # Standardized API response wrappers
-│   └── ApiResponse.php                # MANDATORY Trait for Controllers
+│   └── ApiResponse.php                # MANDATORY class — use ApiResponse::success() / error() / validationError()
 │
 ├── Listeners/
 │   ├── Auth/
@@ -315,6 +315,7 @@ public function process(CheckoutDTO $data): Order { ... }
 ## Architecture Rules — STRICT
 
 1. **Controllers are thin.** A controller method does exactly three things: validate input (via injected `FormRequest`), call a Service method, return a response via `ApiResponse`. No Eloquent queries. No business logic. No `Validator::make()`.
+   - **Exception — Policy delegation:** `$this->authorize('action', $model)` is acceptable in controllers. It delegates to a Laravel Policy class; it is not business logic. Do NOT inline ownership checks — those belong in the Service.
 
 2. **Services own all business logic.** All DB queries, cache reads/writes, event dispatches, and complex logic live in Service classes. Services can call other Services. Never call `response()->json()` from a Service.
 
@@ -330,7 +331,9 @@ public function process(CheckoutDTO $data): Order { ... }
 
 5. **Shared/cross-cutting services live in `app/Services/Shared/`.** If a service is used by more than one domain (e.g., Email, SMS, OTP, File Upload, Push Notification), it MUST go in `Shared/`. Domain services inject Shared services via constructor.
 
-6. **FormRequests for all mutating endpoints.** Every `POST`, `PUT`, `PATCH` endpoint must use a dedicated `FormRequest` subclass.
+6. **FormRequests for all mutating endpoints with input.** Every `POST`, `PUT`, `PATCH` endpoint that accepts a request body MUST use a dedicated `FormRequest` subclass — no inline `$request->validate()`, no `Validator::make()`.
+   - **Bodyless action routes** (e.g., `POST /orders/{id}/cancel`, `DELETE /sessions/{id}`) that carry no input body may use plain `Illuminate\Http\Request`. Authorization for these routes belongs in the Service layer.
+   - `FormRequest::authorize()` is the preferred place for Policy checks when a FormRequest already exists; do not add a FormRequest solely to hold an `authorize()` call.
 
 7. **API Resources wrap all model output.** Never return an Eloquent model or collection directly. Always use a Resource with an explicit `toArray()` whitelist.
 
@@ -427,7 +430,7 @@ Status transitions harus mengikuti alur yang valid. Dilarang melompat status tan
 
 ## Standard Response Envelope
 
-ALL API responses MUST use `App\Http\Responses\ApiResponse`. No exceptions.
+ALL API responses MUST use `App\Http\Responses\ApiResponse` (static class methods). No exceptions.
 
 ```json
 // Success
@@ -519,16 +522,19 @@ PUT  /api/auth/change-password [auth:sanctum]
 
 ## Payment Gateway
 
-Interface pattern in `app/Services/Payment/`:
+Interface pattern in `app/Services/Payment/PaymentGatewayInterface.php`:
 ```php
 interface PaymentGatewayInterface {
-    public function createInvoice(array $data): array;
-    public function capturePayment(string $paymentId): array;
-    public function refundPayment(string $paymentId, int $amount): array;
+    public function createCharge(array $data): array;       // returns: gateway_ref, redirect_url, payment_details, expires_at
+    public function cancelCharge(string $ref, string $method): void;
+    public function getPaymentStatus(string $ref): array;
+    public function refundPayment(string $ref, int $amount): array;
     public function verifyWebhook(Request $request): bool;
+    public function parseWebhookPayload(Request $request): array; // returns: event, external_id, status, amount
 }
 ```
-Bound in `AppServiceProvider` based on `env('PAYMENT_GATEWAY', 'xendit')`.
+Named gateway bindings registered in `AppServiceProvider`: `payment.xendit`, `payment.midtrans`.
+Expiry: configured via `PAYMENT_EXPIRY_MINUTES` (default 15), capped by `order.payment_due_at`.
 Webhook routes are NOT under `auth:sanctum` — use `verifyWebhook()` signature verification.
 
 ---

--- a/app/Http/Controllers/Api/Auth/AuthController.php
+++ b/app/Http/Controllers/Api/Auth/AuthController.php
@@ -135,12 +135,12 @@ class AuthController extends Controller
         return ApiResponse::success('Active sessions retrieved.', $sessions);
     }
 
-    public function revokeSession(Request $request, int $id): JsonResponse
+    public function revokeSession(Request $request, int $id): \Illuminate\Http\Response|JsonResponse
     {
         try {
             $this->authService->revokeSession($request->user(), $id);
 
-            return ApiResponse::success('Session revoked successfully.', null, 200);
+            return response()->noContent();
         } catch (\Exception $e) {
             return ApiResponse::error('Session not found.', 404);
         }

--- a/app/Http/Controllers/Api/Merchant/MerchantController.php
+++ b/app/Http/Controllers/Api/Merchant/MerchantController.php
@@ -32,14 +32,14 @@ class MerchantController extends Controller
 
     public function show(Request $request): JsonResponse
     {
-        $store = $request->user()->store;
+        $store = $this->merchant->getStoreForUser($request->user());
 
         return ApiResponse::success('Store retrieved.', new StoreResource($store));
     }
 
     public function dashboard(Request $request): JsonResponse
     {
-        $store = $request->user()->store;
+        $store = $this->merchant->getStoreForUser($request->user());
         $data  = $this->merchant->getDashboard($store);
 
         return ApiResponse::success('Dashboard retrieved.', [
@@ -52,7 +52,7 @@ class MerchantController extends Controller
 
     public function uploadKyc(UploadKycRequest $request): JsonResponse
     {
-        $store  = $request->user()->store;
+        $store  = $this->merchant->getStoreForUser($request->user());
         $result = $this->merchant->generateKycPresignedUrl(
             $store,
             $request->input('type'),
@@ -65,7 +65,7 @@ class MerchantController extends Controller
 
     public function confirmKyc(ConfirmKycRequest $request): JsonResponse
     {
-        $store    = $request->user()->store;
+        $store    = $this->merchant->getStoreForUser($request->user());
         $document = $this->merchant->confirmKycUpload(
             $store,
             $request->input('type'),
@@ -77,7 +77,7 @@ class MerchantController extends Controller
 
     public function reuploadKyc(UploadKycRequest $request): JsonResponse
     {
-        $store  = $request->user()->store;
+        $store  = $this->merchant->getStoreForUser($request->user());
         $result = $this->merchant->generateKycReuploadUrl(
             $store,
             $request->input('type'),
@@ -90,7 +90,7 @@ class MerchantController extends Controller
 
     public function confirmKycReupload(ConfirmKycRequest $request): JsonResponse
     {
-        $store    = $request->user()->store;
+        $store    = $this->merchant->getStoreForUser($request->user());
         $document = $this->merchant->confirmKycUpload(
             $store,
             $request->input('type'),

--- a/app/Http/Controllers/Api/Merchant/StoreController.php
+++ b/app/Http/Controllers/Api/Merchant/StoreController.php
@@ -20,7 +20,7 @@ class StoreController extends Controller
 
     public function update(UpdateStoreRequest $request): JsonResponse
     {
-        $store   = $request->user()->store;
+        $store   = $this->merchant->getStoreForUser($request->user());
         $updated = $this->merchant->update($store, $request->validated());
 
         return ApiResponse::success('Store updated successfully.', new StoreResource($updated));
@@ -30,7 +30,7 @@ class StoreController extends Controller
 
     public function uploadLogo(UploadStoreMediaRequest $request): JsonResponse
     {
-        $store  = $request->user()->store;
+        $store  = $this->merchant->getStoreForUser($request->user());
         $result = $this->merchant->generateLogoPresignedUrl(
             $store,
             $request->input('filename'),
@@ -42,7 +42,7 @@ class StoreController extends Controller
 
     public function confirmLogo(ConfirmStoreMediaRequest $request): JsonResponse
     {
-        $store   = $request->user()->store;
+        $store   = $this->merchant->getStoreForUser($request->user());
         $updated = $this->merchant->confirmLogoUpload($store, $request->input('key'));
 
         return ApiResponse::success('Logo updated successfully.', new StoreResource($updated));
@@ -50,7 +50,7 @@ class StoreController extends Controller
 
     public function deleteLogo(Request $request): \Illuminate\Http\Response
     {
-        $this->merchant->deleteLogo($request->user()->store);
+        $this->merchant->deleteLogo($this->merchant->getStoreForUser($request->user()));
 
         return response()->noContent();
     }
@@ -59,7 +59,7 @@ class StoreController extends Controller
 
     public function uploadBanner(UploadStoreMediaRequest $request): JsonResponse
     {
-        $store  = $request->user()->store;
+        $store  = $this->merchant->getStoreForUser($request->user());
         $result = $this->merchant->generateBannerPresignedUrl(
             $store,
             $request->input('filename'),
@@ -71,7 +71,7 @@ class StoreController extends Controller
 
     public function confirmBanner(ConfirmStoreMediaRequest $request): JsonResponse
     {
-        $store   = $request->user()->store;
+        $store   = $this->merchant->getStoreForUser($request->user());
         $updated = $this->merchant->confirmBannerUpload($store, $request->input('key'));
 
         return ApiResponse::success('Banner updated successfully.', new StoreResource($updated));
@@ -79,7 +79,7 @@ class StoreController extends Controller
 
     public function deleteBanner(Request $request): \Illuminate\Http\Response
     {
-        $this->merchant->deleteBanner($request->user()->store);
+        $this->merchant->deleteBanner($this->merchant->getStoreForUser($request->user()));
 
         return response()->noContent();
     }

--- a/app/Http/Controllers/Api/Order/MerchantOrderController.php
+++ b/app/Http/Controllers/Api/Order/MerchantOrderController.php
@@ -7,6 +7,7 @@ use App\Http\Requests\Order\ShipOrderRequest;
 use App\Http\Resources\Order\OrderListResource;
 use App\Http\Resources\Order\OrderResource;
 use App\Http\Responses\ApiResponse;
+use App\Services\Merchant\MerchantService;
 use App\Services\Order\OrderService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -15,11 +16,12 @@ class MerchantOrderController extends Controller
 {
     public function __construct(
         private readonly OrderService $orderService,
+        private readonly MerchantService $merchant,
     ) {}
 
     public function index(Request $request): JsonResponse
     {
-        $store  = $request->user()->store;
+        $store  = $this->merchant->getStoreForUser($request->user());
         $orders = $this->orderService->getOrdersForMerchant(
             $store,
             $request->query('status'),
@@ -35,7 +37,7 @@ class MerchantOrderController extends Controller
 
     public function show(Request $request, int $id): JsonResponse
     {
-        $store = $request->user()->store;
+        $store = $this->merchant->getStoreForUser($request->user());
         $order = $this->orderService->findForMerchant($store, $id);
 
         return ApiResponse::success('Order retrieved.', new OrderResource($order));
@@ -43,7 +45,7 @@ class MerchantOrderController extends Controller
 
     public function confirm(Request $request, int $id): JsonResponse
     {
-        $store = $request->user()->store;
+        $store = $this->merchant->getStoreForUser($request->user());
         $order = $this->orderService->findForMerchant($store, $id);
         $order = $this->orderService->confirmByMerchant($store, $order);
 
@@ -52,7 +54,7 @@ class MerchantOrderController extends Controller
 
     public function ship(ShipOrderRequest $request, int $id): JsonResponse
     {
-        $store = $request->user()->store;
+        $store = $this->merchant->getStoreForUser($request->user());
         $order = $this->orderService->findForMerchant($store, $id);
         $order = $this->orderService->shipByMerchant($store, $order, $request->input('tracking_number'));
 

--- a/app/Http/Controllers/Api/Payment/PaymentController.php
+++ b/app/Http/Controllers/Api/Payment/PaymentController.php
@@ -53,6 +53,6 @@ class PaymentController extends Controller
         $payment = $this->paymentService->findForUser($request->user(), $id);
         $refund  = $this->paymentService->requestRefund($payment, $request->input('reason', ''));
 
-        return ApiResponse::success('Refund processed successfully.', new RefundResource($refund));
+        return ApiResponse::success('Refund processed successfully.', new RefundResource($refund), 201);
     }
 }

--- a/app/Http/Controllers/Api/Payment/PaymentController.php
+++ b/app/Http/Controllers/Api/Payment/PaymentController.php
@@ -10,7 +10,6 @@ use App\Http\Requests\Payment\SwitchPaymentRequest;
 use App\Http\Resources\Payment\PaymentResource;
 use App\Http\Resources\Payment\RefundResource;
 use App\Http\Responses\ApiResponse;
-use App\Models\Payment;
 use App\Services\Payment\PaymentService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -32,10 +31,7 @@ class PaymentController extends Controller
 
     public function status(Request $request, int $id): JsonResponse
     {
-        $payment = Payment::where('id', $id)
-            ->whereHas('order', fn ($q) => $q->where('user_id', $request->user()->id))
-            ->firstOrFail();
-
+        $payment = $this->paymentService->findForUser($request->user(), $id);
         $payment = $this->paymentService->getStatus($payment);
 
         return ApiResponse::success('Payment status retrieved.', new PaymentResource($payment));
@@ -43,10 +39,7 @@ class PaymentController extends Controller
 
     public function switch(SwitchPaymentRequest $request, int $id): JsonResponse
     {
-        $payment = Payment::where('id', $id)
-            ->whereHas('order', fn ($q) => $q->where('user_id', $request->user()->id))
-            ->firstOrFail();
-
+        $payment    = $this->paymentService->findForUser($request->user(), $id);
         $newPayment = $this->paymentService->switchPayment(
             $payment,
             InitiatePaymentDTO::fromSwitchRequest($request, $payment->order_id)
@@ -57,11 +50,8 @@ class PaymentController extends Controller
 
     public function refund(RefundPaymentRequest $request, int $id): JsonResponse
     {
-        $payment = Payment::where('id', $id)
-            ->whereHas('order', fn ($q) => $q->where('user_id', $request->user()->id))
-            ->firstOrFail();
-
-        $refund = $this->paymentService->requestRefund($payment, $request->input('reason', ''));
+        $payment = $this->paymentService->findForUser($request->user(), $id);
+        $refund  = $this->paymentService->requestRefund($payment, $request->input('reason', ''));
 
         return ApiResponse::success('Refund processed successfully.', new RefundResource($refund));
     }

--- a/app/Http/Controllers/Api/Product/CategoryController.php
+++ b/app/Http/Controllers/Api/Product/CategoryController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\Product;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Product\StoreCategoryRequest;
 use App\Http\Requests\Product\UpdateCategoryRequest;
+use App\Http\Resources\Product\CategoryResource;
 use App\Http\Responses\ApiResponse;
 use App\Models\Category;
 use App\Services\Product\CategoryService;
@@ -31,56 +32,23 @@ class CategoryController extends Controller
             return ApiResponse::error('Category not found.', 404);
         }
 
-        $category->load('children');
-
-        return ApiResponse::success('Category retrieved.', [
-            'id'         => $category->id,
-            'name'       => $category->name,
-            'slug'       => $category->slug,
-            'icon'       => $category->icon,
-            'level'      => $category->level,
-            'sort_order' => $category->sort_order,
-            'children'   => $category->children->map(fn ($child) => [
-                'id'    => $child->id,
-                'name'  => $child->name,
-                'slug'  => $child->slug,
-                'level' => $child->level,
-            ])->values()->all(),
-        ]);
+        return ApiResponse::success('Category retrieved.', new CategoryResource($category->load('children')));
     }
 
     // ── Admin ─────────────────────────────────────────────────────────────────
 
     public function store(StoreCategoryRequest $request): JsonResponse
     {
-        $data = $request->validated();
+        $category = $this->categories->create($request->validated());
 
-        if (isset($data['parent_id'])) {
-            $parent = Category::find($data['parent_id']);
-            $data['level'] = $parent->level + 1;
-        } else {
-            $data['level'] = 1;
-        }
-
-        $data['sort_order'] = $data['sort_order'] ?? 0;
-
-        $category = $this->categories->create($data);
-
-        return ApiResponse::success('Category created.', $this->formatCategory($category), 201);
+        return ApiResponse::success('Category created.', new CategoryResource($category), 201);
     }
 
     public function update(UpdateCategoryRequest $request, Category $category): JsonResponse
     {
-        $data = $request->validated();
+        $updated = $this->categories->update($category, $request->validated());
 
-        if (isset($data['parent_id'])) {
-            $parent = Category::find($data['parent_id']);
-            $data['level'] = $parent->level + 1;
-        }
-
-        $updated = $this->categories->update($category, $data);
-
-        return ApiResponse::success('Category updated.', $this->formatCategory($updated));
+        return ApiResponse::success('Category updated.', new CategoryResource($updated));
     }
 
     public function destroy(Category $category): \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
@@ -96,18 +64,5 @@ class CategoryController extends Controller
         $this->categories->delete($category);
 
         return response()->noContent();
-    }
-
-    private function formatCategory(Category $category): array
-    {
-        return [
-            'id'         => $category->id,
-            'name'       => $category->name,
-            'slug'       => $category->slug,
-            'icon'       => $category->icon,
-            'level'      => $category->level,
-            'sort_order' => $category->sort_order,
-            'parent_id'  => $category->parent_id,
-        ];
     }
 }

--- a/app/Http/Controllers/Api/Product/CategoryController.php
+++ b/app/Http/Controllers/Api/Product/CategoryController.php
@@ -51,16 +51,8 @@ class CategoryController extends Controller
         return ApiResponse::success('Category updated.', new CategoryResource($updated));
     }
 
-    public function destroy(Category $category): \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+    public function destroy(Category $category): \Illuminate\Http\Response
     {
-        if ($category->children()->count() > 0) {
-            return ApiResponse::error('Cannot delete a category that has children.', 422);
-        }
-
-        if ($category->products()->count() > 0) {
-            return ApiResponse::error('Cannot delete a category that has products.', 422);
-        }
-
         $this->categories->delete($category);
 
         return response()->noContent();

--- a/app/Http/Controllers/Api/Product/ProductController.php
+++ b/app/Http/Controllers/Api/Product/ProductController.php
@@ -13,6 +13,7 @@ use App\Http\Resources\Product\ProductListResource;
 use App\Http\Resources\Product\ProductResource;
 use App\Http\Responses\ApiResponse;
 use App\Models\Product;
+use App\Services\Merchant\MerchantService;
 use App\Services\Product\ProductService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -21,6 +22,7 @@ class ProductController extends Controller
 {
     public function __construct(
         private readonly ProductService $products,
+        private readonly MerchantService $merchant,
     ) {}
 
     // ── Public ────────────────────────────────────────────────────────────────
@@ -57,7 +59,7 @@ class ProductController extends Controller
 
     public function merchantIndex(Request $request): JsonResponse
     {
-        $storeId = $request->user()->store->id;
+        $storeId = $this->merchant->getStoreForUser($request->user())->id;
         $paginator = $this->products->getMerchantProducts($storeId);
 
         return ApiResponse::success('Products retrieved.', ProductListResource::collection($paginator), paginationMeta: [
@@ -70,7 +72,7 @@ class ProductController extends Controller
 
     public function store(StoreProductRequest $request): JsonResponse
     {
-        $store = $request->user()->store;
+        $store = $this->merchant->getStoreForUser($request->user());
         $product = $this->products->create(CreateProductDTO::fromRequest($request, $store->id));
 
         return ApiResponse::success('Product created.', new ProductResource($product), 201);

--- a/app/Http/Controllers/Api/Store/StoreFollowerController.php
+++ b/app/Http/Controllers/Api/Store/StoreFollowerController.php
@@ -3,9 +3,8 @@
 namespace App\Http\Controllers\Api\Store;
 
 use App\Http\Controllers\Controller;
-use App\Http\Resources\Merchant\StoreSummaryResource;
+use App\Http\Resources\Merchant\StoreFollowerResource;
 use App\Http\Responses\ApiResponse;
-use App\Models\Store;
 use App\Services\Merchant\MerchantService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -18,10 +17,10 @@ class StoreFollowerController extends Controller
 
     public function followers(string $slug): JsonResponse
     {
-        $store     = Store::where('slug', $slug)->firstOrFail();
-        $followers = $store->followers()->with('user:id,name,avatar')->paginate(20);
+        $store     = $this->merchant->getPublicProfile($slug);
+        $followers = $this->merchant->getFollowers($store);
 
-        return ApiResponse::success('Followers retrieved.', $followers->items(), paginationMeta: [
+        return ApiResponse::success('Followers retrieved.', StoreFollowerResource::collection($followers->items()), paginationMeta: [
             'current_page' => $followers->currentPage(),
             'last_page'    => $followers->lastPage(),
             'per_page'     => $followers->perPage(),
@@ -31,17 +30,17 @@ class StoreFollowerController extends Controller
 
     public function follow(Request $request, string $slug): JsonResponse
     {
-        $store = Store::where('slug', $slug)->firstOrFail();
+        $store = $this->merchant->getPublicProfile($slug);
         $this->merchant->follow($request->user(), $store);
 
-        return ApiResponse::success('Store followed successfully.');
+        return ApiResponse::success('Store followed successfully.', null, 201);
     }
 
-    public function unfollow(Request $request, string $slug): JsonResponse
+    public function unfollow(Request $request, string $slug): \Illuminate\Http\Response
     {
-        $store = Store::where('slug', $slug)->firstOrFail();
+        $store = $this->merchant->getPublicProfile($slug);
         $this->merchant->unfollow($request->user(), $store);
 
-        return ApiResponse::success('Store unfollowed successfully.');
+        return response()->noContent();
     }
 }

--- a/app/Http/Controllers/Api/User/UserController.php
+++ b/app/Http/Controllers/Api/User/UserController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\User;
 
 use App\Contracts\Shared\MediaServiceInterface;
 use App\Http\Controllers\Controller;
+use App\Http\Requests\User\ConfirmAvatarRequest;
 use App\Http\Requests\User\SendPhoneOtpRequest;
 use App\Http\Requests\User\UpdateProfileRequest;
 use App\Http\Requests\User\UploadAvatarRequest;
@@ -44,10 +45,8 @@ class UserController extends Controller
         return ApiResponse::success('Avatar presigned URL generated.', $result, 201);
     }
 
-    public function confirmAvatar(Request $request): JsonResponse
+    public function confirmAvatar(ConfirmAvatarRequest $request): JsonResponse
     {
-        $request->validate(['key' => ['required', 'string', 'max:500']]);
-
         $key       = $request->input('key');
         $confirmed = $this->media->confirmUpload($key);
 

--- a/app/Http/Requests/User/ConfirmAvatarRequest.php
+++ b/app/Http/Requests/User/ConfirmAvatarRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\User;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConfirmAvatarRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'key' => ['required', 'string', 'max:500'],
+        ];
+    }
+}

--- a/app/Http/Resources/Merchant/StoreFollowerResource.php
+++ b/app/Http/Resources/Merchant/StoreFollowerResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources\Merchant;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class StoreFollowerResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'user_id'     => $this->user_id,
+            'name'        => $this->user?->name,
+            'avatar_url'  => $this->user?->avatar
+                ? rtrim(config('filesystems.disks.r2.url'), '/') . '/' . $this->user->avatar
+                : null,
+            'followed_at' => $this->created_at?->toISOString(),
+        ];
+    }
+}

--- a/app/Http/Resources/Product/CategoryResource.php
+++ b/app/Http/Resources/Product/CategoryResource.php
@@ -16,6 +16,7 @@ class CategoryResource extends JsonResource
             'icon'       => $this->icon,
             'level'      => $this->level,
             'sort_order' => $this->sort_order,
+            'parent_id'  => $this->parent_id,
             'children'   => static::collection($this->whenLoaded('children')),
         ];
     }

--- a/app/Services/Merchant/MerchantService.php
+++ b/app/Services/Merchant/MerchantService.php
@@ -201,6 +201,11 @@ class MerchantService
         StoreUnfollowed::dispatch($store);
     }
 
+    public function getStoreForUser(User $user): Store
+    {
+        return $user->store()->firstOrFail();
+    }
+
     public function getPublicProfile(string $slug): Store
     {
         return $this->cache->remember(

--- a/app/Services/Merchant/MerchantService.php
+++ b/app/Services/Merchant/MerchantService.php
@@ -17,6 +17,7 @@ use App\Models\Store;
 use App\Models\StoreDocument;
 use App\Models\StoreFollower;
 use App\Models\User;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Str;
 
 class MerchantService
@@ -207,6 +208,11 @@ class MerchantService
             600,
             fn () => Store::where('slug', $slug)->firstOrFail(),
         );
+    }
+
+    public function getFollowers(Store $store): LengthAwarePaginator
+    {
+        return $store->followers()->with('user:id,name,avatar')->paginate(20);
     }
 
     public function getDashboard(Store $store): array

--- a/app/Services/Payment/PaymentService.php
+++ b/app/Services/Payment/PaymentService.php
@@ -15,6 +15,7 @@ use App\Models\Payment;
 use App\Models\Refund;
 use App\Models\Transaction;
 use App\Contracts\Shared\IdempotencyServiceInterface;
+use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 
@@ -75,6 +76,13 @@ class PaymentService
             $payment->update(['status' => PaymentStatus::Expired]);
             $payment->transaction?->update(['status' => TransactionStatus::Expired]);
         }
+    }
+
+    public function findForUser(User $user, int $id): Payment
+    {
+        return Payment::where('id', $id)
+            ->whereHas('order', fn ($q) => $q->where('user_id', $user->id))
+            ->firstOrFail();
     }
 
     public function getStatus(Payment $payment): Payment

--- a/app/Services/Product/CategoryService.php
+++ b/app/Services/Product/CategoryService.php
@@ -37,6 +37,14 @@ class CategoryService
 
     public function create(array $data): Category
     {
+        if (isset($data['parent_id'])) {
+            $parent = Category::find($data['parent_id']);
+            $data['level'] = ($parent?->level ?? 0) + 1;
+        } else {
+            $data['level'] = 1;
+        }
+        $data['sort_order'] = $data['sort_order'] ?? 0;
+
         $category = Category::create($data);
         $this->cache->forget('category:tree');
         return $category;
@@ -44,6 +52,11 @@ class CategoryService
 
     public function update(Category $category, array $data): Category
     {
+        if (isset($data['parent_id'])) {
+            $parent = Category::find($data['parent_id']);
+            $data['level'] = ($parent?->level ?? 0) + 1;
+        }
+
         $oldSlug = $category->slug;
         $category->update($data);
         $this->cache->forget('category:tree');

--- a/app/Services/Product/CategoryService.php
+++ b/app/Services/Product/CategoryService.php
@@ -69,6 +69,14 @@ class CategoryService
 
     public function delete(Category $category): void
     {
+        if ($category->children()->count() > 0) {
+            throw new \DomainException('Cannot delete a category that has children.');
+        }
+
+        if ($category->products()->count() > 0) {
+            throw new \DomainException('Cannot delete a category that has products.');
+        }
+
         $this->cache->forget('category:tree');
         $this->cache->forget("category:slug:{$category->slug}");
         $category->delete();

--- a/tests/Feature/Api/Auth/AuthTest.php
+++ b/tests/Feature/Api/Auth/AuthTest.php
@@ -404,7 +404,7 @@ class AuthTest extends TestCase
 
         $response = $this->actingAs($user)->deleteJson("/api/auth/sessions/{$token->id}");
 
-        $response->assertStatus(200)->assertJson(['success' => true]);
+        $response->assertStatus(204);
         $this->assertNotNull($token->fresh()->revoked_at);
     }
 

--- a/tests/Feature/Api/Merchant/StoreTest.php
+++ b/tests/Feature/Api/Merchant/StoreTest.php
@@ -72,7 +72,7 @@ class StoreTest extends TestCase
 
         $this->actingAs($user)
             ->postJson("/api/stores/{$store->slug}/follow")
-            ->assertStatus(200)
+            ->assertStatus(201)
             ->assertJson(['success' => true]);
 
         $this->assertDatabaseHas('store_followers', ['store_id' => $store->id, 'user_id' => $user->id]);
@@ -111,8 +111,7 @@ class StoreTest extends TestCase
 
         $this->actingAs($user)
             ->deleteJson("/api/stores/{$store->slug}/follow")
-            ->assertStatus(200)
-            ->assertJson(['success' => true]);
+            ->assertStatus(204);
 
         $this->assertDatabaseMissing('store_followers', ['store_id' => $store->id, 'user_id' => $user->id]);
     }

--- a/tests/Feature/Api/Payment/PaymentTest.php
+++ b/tests/Feature/Api/Payment/PaymentTest.php
@@ -238,7 +238,7 @@ class PaymentTest extends TestCase
 
         $this->actingAs($buyer)->postJson("/api/payments/{$payment->id}/refund", [
             'reason' => 'Item not received',
-        ])->assertStatus(200)->assertJsonStructure(['data' => ['id', 'status', 'amount_cents']]);
+        ])->assertStatus(201)->assertJsonStructure(['data' => ['id', 'status', 'amount_cents']]);
 
         $this->assertDatabaseHas('refunds', ['payment_id' => $payment->id]);
     }


### PR DESCRIPTION
## Summary

- **Rule 1 (no Eloquent in controllers):** Moved ownership guard queries out of `PaymentController` → `PaymentService::findForUser()`, category child/product guards out of `CategoryController` → `CategoryService::delete()`, and all `$request->user()->store` lazy-load accesses out of Merchant/Order/Product controllers → `MerchantService::getStoreForUser()`
- **Resource wrapping:** `StoreFollowerController` now returns `StoreFollowerResource` instead of raw paginator items; `CategoryController` uses existing `CategoryResource` instead of a private `formatCategory()` helper
- **HTTP 204 on DELETE:** `AuthController::revokeSession` and `StoreFollowerController::unfollow` now return `response()->noContent()` instead of 200
- **HTTP 201 on POST/create:** `StoreFollowerController::follow` → 201; `PaymentController::refund` → 201
- **FormRequest:** `ConfirmAvatarRequest` replaces inline `$request->validate()` in `UserController::confirmAvatar`
- **CLAUDE.md:** Fixed 4 contradictions — Rule 1 Policy exception clause, Rule 6 bodyless-action carve-out, `ApiResponse` trait→class, `PaymentGatewayInterface` method signatures corrected

## Bug Fixes

- `CategoryResource` was missing `parent_id` field — child category tests were asserting it
- `api-audit` skill template had wrong `ApiResponse::success()` signature (`extraMeta` → `paginationMeta` with nested `meta.pagination` shape)

## Test Plan

- [x] 262 tests pass, 1 skipped (`php artisan test`)
- [x] `PaymentTest::buyer_can_refund_paid_payment` updated to assert 201
- [x] `AuthTest::test_user_can_revoke_a_session` updated to assert 204
- [x] `StoreTest` follow/unfollow updated to assert 201/204

## Notes

- `AuthController::sessions()` and `CategoryController::index()` still return raw service data without dedicated Resources (WARN level) — low priority, no security impact
- `CartController::destroy()` returns 200 + body on DELETE — intentional UX (returns updated cart state), acceptable per CLAUDE.md "no body → 204" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)