### PR TITLE
fix(payment): payment expiry hardening — cancel order, SOT guard, wallet recovery

### DIFF
--- a/app/Listeners/Payment/CancelOrderOnPaymentFailed.php
+++ b/app/Listeners/Payment/CancelOrderOnPaymentFailed.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Listeners\Payment;
+
+use App\Enums\OrderStatus;
+use App\Events\Order\OrderCancelled;
+use App\Events\Payment\PaymentFailed;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class CancelOrderOnPaymentFailed implements ShouldQueue
+{
+    public function handle(PaymentFailed $event): void
+    {
+        $order = $event->payment->order;
+
+        if (! $order || $order->status !== OrderStatus::Pending) {
+            return;
+        }
+
+        $order->update(['status' => OrderStatus::Cancelled]);
+
+        OrderCancelled::dispatch($order);
+    }
+}

--- a/app/Services/Payment/PaymentService.php
+++ b/app/Services/Payment/PaymentService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Payment;
 
+use App\Contracts\Shared\IdempotencyServiceInterface;
 use App\DTOs\Payment\InitiatePaymentDTO;
 use App\Enums\OrderStatus;
 use App\Enums\PaymentStatus;
@@ -14,7 +15,6 @@ use App\Models\Order;
 use App\Models\Payment;
 use App\Models\Refund;
 use App\Models\Transaction;
-use App\Contracts\Shared\IdempotencyServiceInterface;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -25,6 +25,7 @@ class PaymentService
     public function __construct(
         private readonly PaymentGatewayInterface $gateway,
         private readonly IdempotencyServiceInterface $idempotency,
+        private readonly WalletService $wallet,
     ) {}
 
     public function initiatePayment(InitiatePaymentDTO $data): Payment
@@ -152,13 +153,9 @@ class PaymentService
                     return;
                 }
 
-                Log::critical('Paid webhook for expired/failed payment — order already processed, possible double charge', [
-                    'payment_id'   => $payment->id,
-                    'order_id'     => $payment->order_id,
-                    'order_status' => $order?->status->value,
-                    'gateway_ref'  => $externalId,
-                    'gateway'      => $payment->gateway,
-                ]);
+                // Order already fulfilled — this is a duplicate payment.
+                // Auto-credit the user's wallet so the money is not lost.
+                $this->refundDoubleChargeToWallet($payment, $normalized['amount'], $externalId);
             }
             return;
         }
@@ -307,6 +304,46 @@ class PaymentService
             'status'          => PaymentStatus::Pending,
             'payment_details' => $result['payment_details'],
             'expires_at'      => $result['expires_at'] ? now()->parse($result['expires_at']) : $paymentExpiresAt,
+        ]);
+    }
+
+    private function refundDoubleChargeToWallet(Payment $payment, int $amount, string $gatewayRef): void
+    {
+        $user = $payment->order?->user;
+
+        if (! $user) {
+            Log::critical('Double payment detected but could not resolve user — manual refund required', [
+                'payment_id'  => $payment->id,
+                'gateway_ref' => $gatewayRef,
+                'gateway'     => $payment->gateway,
+                'amount'      => $amount,
+            ]);
+            return;
+        }
+
+        Refund::create([
+            'payment_id'  => $payment->id,
+            'amount'      => $amount,
+            'reason'      => "Duplicate payment auto-refunded to wallet (gateway ref: {$gatewayRef})",
+            'status'      => RefundStatus::Processed,
+            'refunded_at' => now(),
+        ]);
+
+        $this->wallet->creditUser(
+            $user,
+            $amount,
+            "Duplicate payment refunded to wallet (ref: {$gatewayRef})",
+            Payment::class,
+            $payment->id,
+        );
+
+        Log::critical('Double payment detected — auto-credited user wallet', [
+            'payment_id'  => $payment->id,
+            'order_id'    => $payment->order_id,
+            'user_id'     => $user->id,
+            'gateway_ref' => $gatewayRef,
+            'gateway'     => $payment->gateway,
+            'amount'      => $amount,
         ]);
     }
 

--- a/app/Services/Payment/PaymentService.php
+++ b/app/Services/Payment/PaymentService.php
@@ -125,21 +125,39 @@ class PaymentService
             return; // Unknown payment — skip silently
         }
 
-        // Skip if already in a terminal state
-        $terminalStatuses = [
-            PaymentStatus::Paid,
-            PaymentStatus::Expired,
-            PaymentStatus::Failed,
-            PaymentStatus::Refunded,
-        ];
+        // Hard-terminal: Paid and Refunded are truly final — no recovery possible
+        if (in_array($payment->status, [PaymentStatus::Paid, PaymentStatus::Refunded])) {
+            return;
+        }
 
-        if (in_array($payment->status, $terminalStatuses)) {
-            if ($status === 'paid' && in_array($payment->status, [PaymentStatus::Expired, PaymentStatus::Failed])) {
-                Log::critical('Received paid webhook for expired/failed payment — possible double charge', [
+        // Soft-terminal: Expired or Failed — a paid webhook means money reached the gateway.
+        // This happens when: (a) scheduler expired locally before gateway did, or
+        // (b) a switched-away invoice's cancelCharge failed and the user paid on the old one.
+        // If the order is still unfulfilled we can recover; otherwise it's a true double-charge.
+        if (in_array($payment->status, [PaymentStatus::Expired, PaymentStatus::Failed])) {
+            if ($status === 'paid') {
+                $order = $payment->order;
+
+                if ($order && $order->status === OrderStatus::Pending) {
+                    Log::warning('Paid webhook for locally-expired payment — order still pending, recovering', [
+                        'payment_id'   => $payment->id,
+                        'order_id'     => $order->id,
+                        'gateway_ref'  => $externalId,
+                        'gateway'      => $payment->gateway,
+                        'local_status' => $payment->status->value,
+                    ]);
+                    // Expire any other pending payments for this order (e.g. Payment B from switch)
+                    $this->cancelPendingPaymentsForOrder($order);
+                    $this->markPaid($payment, $normalized['amount']);
+                    return;
+                }
+
+                Log::critical('Paid webhook for expired/failed payment — order already processed, possible double charge', [
                     'payment_id'   => $payment->id,
+                    'order_id'     => $payment->order_id,
+                    'order_status' => $order?->status->value,
                     'gateway_ref'  => $externalId,
                     'gateway'      => $payment->gateway,
-                    'local_status' => $payment->status->value,
                 ]);
             }
             return;

--- a/app/Services/Payment/PaymentService.php
+++ b/app/Services/Payment/PaymentService.php
@@ -199,8 +199,26 @@ class PaymentService
 
     public function expireUnpaidPayments(): int
     {
+        $graceConfig = config('payment.expiry_grace_minutes', []);
+        $defaultGrace = 30;
+
         $expired = Payment::where('status', PaymentStatus::Pending)
-            ->where('expires_at', '<', now())
+            ->where(function ($query) use ($graceConfig, $defaultGrace) {
+                foreach ($graceConfig as $gateway => $graceMinutes) {
+                    $query->orWhere(function ($q) use ($gateway, $graceMinutes) {
+                        $q->where('gateway', $gateway)
+                          ->where('expires_at', '<', now()->subMinutes($graceMinutes));
+                    });
+                }
+                // Fallback: any gateway not explicitly configured uses default grace
+                $knownGateways = array_keys($graceConfig);
+                if (! empty($knownGateways)) {
+                    $query->orWhere(function ($q) use ($knownGateways, $defaultGrace) {
+                        $q->whereNotIn('gateway', $knownGateways)
+                          ->where('expires_at', '<', now()->subMinutes($defaultGrace));
+                    });
+                }
+            })
             ->get();
 
         foreach ($expired as $payment) {

--- a/app/Services/Payment/PaymentService.php
+++ b/app/Services/Payment/PaymentService.php
@@ -17,6 +17,7 @@ use App\Models\Transaction;
 use App\Contracts\Shared\IdempotencyServiceInterface;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class PaymentService
@@ -52,7 +53,14 @@ class PaymentService
         try {
             $oldGateway = app("payment.{$currentPayment->gateway}");
             $oldGateway->cancelCharge($currentPayment->gateway_ref, $currentPayment->method);
-        } catch (\Throwable) {}
+        } catch (\Throwable $e) {
+            Log::warning('Failed to cancel old gateway charge on payment switch', [
+                'payment_id'  => $currentPayment->id,
+                'gateway_ref' => $currentPayment->gateway_ref,
+                'gateway'     => $currentPayment->gateway,
+                'error'       => $e->getMessage(),
+            ]);
+        }
 
         $currentPayment->update(['status' => PaymentStatus::Expired]);
         $currentPayment->transaction?->update(['status' => TransactionStatus::Expired]);
@@ -118,7 +126,22 @@ class PaymentService
         }
 
         // Skip if already in a terminal state
-        if (in_array($payment->status, [PaymentStatus::Paid, PaymentStatus::Refunded])) {
+        $terminalStatuses = [
+            PaymentStatus::Paid,
+            PaymentStatus::Expired,
+            PaymentStatus::Failed,
+            PaymentStatus::Refunded,
+        ];
+
+        if (in_array($payment->status, $terminalStatuses)) {
+            if ($status === 'paid' && in_array($payment->status, [PaymentStatus::Expired, PaymentStatus::Failed])) {
+                Log::critical('Received paid webhook for expired/failed payment — possible double charge', [
+                    'payment_id'   => $payment->id,
+                    'gateway_ref'  => $externalId,
+                    'gateway'      => $payment->gateway,
+                    'local_status' => $payment->status->value,
+                ]);
+            }
             return;
         }
 

--- a/config/payment.php
+++ b/config/payment.php
@@ -3,4 +3,18 @@
 return [
     'default_gateway'  => env('PAYMENT_GATEWAY', 'xendit'),
     'expiry_minutes'   => (int) env('PAYMENT_EXPIRY_MINUTES', 15),
+
+    /*
+     * Scheduler safety-net grace period per gateway (minutes).
+     *
+     * Xendit  → webhook arrives quickly; 30-min grace is enough.
+     * Midtrans → VA payments at the bank can stay payable for up to 24 hours
+     *            regardless of the Snap session expiry we set. We rely on the
+     *            settlement/expire webhook as the source of truth. The scheduler
+     *            only fires as an absolute last resort after this grace period.
+     */
+    'expiry_grace_minutes' => [
+        'xendit'   => (int) env('PAYMENT_EXPIRY_GRACE_XENDIT', 30),
+        'midtrans' => (int) env('PAYMENT_EXPIRY_GRACE_MIDTRANS', 1440), // 24 hours
+    ],
 ];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,23 @@ services:
             - redis
             - app
 
+    scheduler:
+        build:
+            context: .
+            dockerfile: docker/php/Dockerfile
+            target: development
+        container_name: laravel-scheduler
+        restart: unless-stopped
+        command: php artisan schedule:work
+        volumes:
+            - .:/var/www/html
+        networks:
+            - laravel
+        depends_on:
+            - mysql
+            - redis
+            - app
+
     nginx:
         image: nginx:alpine
         container_name: laravel-nginx

--- a/tests/Feature/Api/Payment/WebhookTest.php
+++ b/tests/Feature/Api/Payment/WebhookTest.php
@@ -191,6 +191,54 @@ class WebhookTest extends TestCase
         $this->assertDatabaseHas('orders', ['id' => $order->id, 'status' => OrderStatus::Paid->value]);
     }
 
+    // ── Recovery: paid webhook on locally-expired payment ────────────────────
+
+    public function test_paid_webhook_recovers_locally_expired_payment_when_order_is_pending(): void
+    {
+        Event::fake();
+        $this->mockGateway('paid', 'PAY-RECOVER');
+        $user    = User::factory()->create(['email_verified_at' => now()]);
+        $order   = Order::factory()->create(['user_id' => $user->id, 'status' => OrderStatus::Pending, 'total' => 10000000]);
+        // Simulate scheduler having expired the payment locally (soft-terminal)
+        $payment = Payment::factory()->create([
+            'order_id'    => $order->id,
+            'gateway_ref' => 'PAY-RECOVER',
+            'status'      => PaymentStatus::Expired,
+            'amount'      => 10000000,
+        ]);
+
+        $this->postJson('/api/webhooks/xendit', ['external_id' => 'PAY-RECOVER', 'status' => 'PAID'])
+            ->assertStatus(200);
+
+        // Payment must be recovered to Paid
+        $this->assertDatabaseHas('payments', ['id' => $payment->id, 'status' => PaymentStatus::Paid->value]);
+        // Order must be fulfilled
+        Event::assertDispatched(PaymentCaptured::class);
+    }
+
+    public function test_paid_webhook_on_expired_payment_does_not_recover_already_paid_order(): void
+    {
+        Event::fake();
+        $this->mockGateway('paid', 'PAY-DOUBLEP');
+        $user    = User::factory()->create(['email_verified_at' => now()]);
+        $order   = Order::factory()->create(['user_id' => $user->id, 'status' => OrderStatus::Paid, 'total' => 10000000]);
+        // Old expired payment for an already-paid order (true double-charge scenario)
+        Payment::factory()->create([
+            'order_id'    => $order->id,
+            'gateway_ref' => 'PAY-DOUBLEP',
+            'status'      => PaymentStatus::Expired,
+            'amount'      => 10000000,
+        ]);
+
+        $this->postJson('/api/webhooks/xendit', ['external_id' => 'PAY-DOUBLEP', 'status' => 'PAID'])
+            ->assertStatus(200);
+
+        // No PaymentCaptured — order was already paid, this is a double-charge
+        Event::assertNotDispatched(PaymentCaptured::class);
+        // Order stays Paid
+        $this->assertDatabaseHas('orders', ['id' => $order->id, 'status' => OrderStatus::Paid->value]);
+    }
+
     // ── Midtrans webhook ──────────────────────────────────────────────────────
 
     public function test_midtrans_webhook_marks_payment_paid(): void

--- a/tests/Feature/Api/Payment/WebhookTest.php
+++ b/tests/Feature/Api/Payment/WebhookTest.php
@@ -162,6 +162,35 @@ class WebhookTest extends TestCase
         Mail::assertQueued(PaymentExpiredMail::class, fn ($mail) => $mail->payment->id === $payment->id);
     }
 
+    public function test_expire_webhook_cancels_pending_order(): void
+    {
+        $this->mockGateway('expired', 'PAY-CANCEL-TEST');
+        ['order' => $order] = $this->paymentWithOrder('PAY-CANCEL-TEST');
+
+        $this->postJson('/api/webhooks/xendit', ['external_id' => 'PAY-CANCEL-TEST', 'status' => 'EXPIRED'])
+            ->assertStatus(200);
+
+        $this->assertDatabaseHas('orders', [
+            'id'     => $order->id,
+            'status' => OrderStatus::Cancelled->value,
+        ]);
+    }
+
+    public function test_expire_webhook_does_not_cancel_non_pending_order(): void
+    {
+        $this->mockGateway('expired', 'PAY-PAID-CANCEL');
+        $user    = User::factory()->create(['email_verified_at' => now()]);
+        $order   = Order::factory()->create(['user_id' => $user->id, 'status' => OrderStatus::Paid, 'total' => 10000000]);
+        $payment = Payment::factory()->paid()->create(['order_id' => $order->id, 'gateway_ref' => 'PAY-PAID-CANCEL']);
+
+        // Paid order — PaymentFailed won't be dispatched (terminal state guard)
+        $this->postJson('/api/webhooks/xendit', ['external_id' => 'PAY-PAID-CANCEL', 'status' => 'EXPIRED'])
+            ->assertStatus(200);
+
+        // Order must stay Paid
+        $this->assertDatabaseHas('orders', ['id' => $order->id, 'status' => OrderStatus::Paid->value]);
+    }
+
     // ── Midtrans webhook ──────────────────────────────────────────────────────
 
     public function test_midtrans_webhook_marks_payment_paid(): void

--- a/tests/Feature/Api/Payment/WebhookTest.php
+++ b/tests/Feature/Api/Payment/WebhookTest.php
@@ -216,14 +216,13 @@ class WebhookTest extends TestCase
         Event::assertDispatched(PaymentCaptured::class);
     }
 
-    public function test_paid_webhook_on_expired_payment_does_not_recover_already_paid_order(): void
+    public function test_double_charge_webhook_auto_credits_user_wallet(): void
     {
         Event::fake();
         $this->mockGateway('paid', 'PAY-DOUBLEP');
         $user    = User::factory()->create(['email_verified_at' => now()]);
         $order   = Order::factory()->create(['user_id' => $user->id, 'status' => OrderStatus::Paid, 'total' => 10000000]);
-        // Old expired payment for an already-paid order (true double-charge scenario)
-        Payment::factory()->create([
+        $payment = Payment::factory()->create([
             'order_id'    => $order->id,
             'gateway_ref' => 'PAY-DOUBLEP',
             'status'      => PaymentStatus::Expired,
@@ -233,10 +232,18 @@ class WebhookTest extends TestCase
         $this->postJson('/api/webhooks/xendit', ['external_id' => 'PAY-DOUBLEP', 'status' => 'PAID'])
             ->assertStatus(200);
 
-        // No PaymentCaptured — order was already paid, this is a double-charge
+        // No PaymentCaptured — order already paid
         Event::assertNotDispatched(PaymentCaptured::class);
         // Order stays Paid
         $this->assertDatabaseHas('orders', ['id' => $order->id, 'status' => OrderStatus::Paid->value]);
+        // Refund record created for audit
+        $this->assertDatabaseHas('refunds', ['payment_id' => $payment->id]);
+        // User wallet credited with duplicate amount
+        $this->assertDatabaseHas('wallet_transactions', [
+            'type'         => 'credit',
+            'amount'       => 10000000,
+            'reference_id' => $payment->id,
+        ]);
     }
 
     // ── Midtrans webhook ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Order cancellation on payment expire**: new `CancelOrderOnPaymentFailed` listener cancels the order (and dispatches `OrderCancelled`) when a payment expires or fails, restoring stock and triggering downstream refund logic
- **Terminal state guard expanded**: scheduler + webhook race condition fixed — `Expired` and `Failed` are now soft-terminal (smart recovery) while `Paid` and `Refunded` remain hard-terminal
- **Webhook-primary expiry**: per-gateway grace buffer added (`xendit=30min`, `midtrans=1440min`) so scheduler only fires as last resort after the gateway webhook has had time to arrive
- **Smart recovery for locally-expired payments**: paid webhook on Expired/Failed payment with a still-Pending order → recover (cancel any other pending payments, fulfil the order) instead of blocking
- **Double-charge wallet credit**: paid webhook on Expired/Failed payment with an already-Paid order → auto-credit user wallet + create Refund audit record + `Log::critical` for Grafana review
- **cancelCharge logging**: silent failure in `switchPayment()` now logs `Log::warning` with gateway context
- **Scheduler container**: `laravel-scheduler` service added to `docker-compose.yml` — `ExpireUnpaidPayments` and `orders:cancel-expired` were registered but never running

## Bug Fixes

- `CancelOrderOnPaymentFailed` listener was missing entirely — expired payments never cancelled the order
- Terminal state guard only blocked `Paid` and `Refunded`; `Expired` and `Failed` were missing, allowing duplicate `PaymentFailed` events from scheduler + webhook race
- `switchPayment()` swallowed `cancelCharge` errors silently with no log
- Docker had no `scheduler` service — `php artisan schedule:work` was never executed

## Test Plan

- [x] `php artisan test --filter=Payment` — 32 assertions, all pass
- [x] `test_expire_webhook_cancels_pending_order` — order becomes Cancelled after EXPIRED webhook
- [x] `test_expire_webhook_does_not_cancel_non_pending_order` — Paid order stays Paid
- [x] `test_paid_webhook_recovers_locally_expired_payment_when_order_is_pending` — recovery path
- [x] `test_double_charge_webhook_auto_credits_user_wallet` — wallet credit + refund record created

## Notes

- `planning/07b-payment-sot-hardening.md` created and approved — next branch `fix/payment-sot-hardening` will add async webhook processing, dual verification, and active reconciliation job
- Grace buffer values overridable via env: `PAYMENT_EXPIRY_GRACE_XENDIT`, `PAYMENT_EXPIRY_GRACE_MIDTRANS`